### PR TITLE
feat(tasks): interactive PM widget

### DIFF
--- a/src/toad/screens/task_detail_screen.py
+++ b/src/toad/screens/task_detail_screen.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import VerticalScroll
+from textual.css.query import NoMatches
 from textual.screen import Screen
 from textual.widgets import Footer, Header, Markdown, Static
 
@@ -17,7 +18,13 @@ from toad.widgets.github_views.task_provider import TaskDetailData, TaskItem
 
 
 class TaskDetailScreen(Screen[None]):
-    """Full-screen task detail with Escape-to-pop."""
+    """Full-screen task detail with Escape-to-pop.
+
+    Constructed with just the :class:`TaskItem`; the owning pane calls
+    :meth:`set_details` once the async fetch completes, so the screen
+    always shows the latest body and linked PRs even if the user drilled
+    in before the fetch returned.
+    """
 
     BINDINGS = [
         Binding("escape", "app.pop_screen", "Back"),
@@ -34,6 +41,10 @@ class TaskDetailScreen(Screen[None]):
     TaskDetailScreen .task-screen-meta {
         color: $text-muted;
         padding-bottom: 1;
+    }
+    TaskDetailScreen .task-screen-error {
+        color: $error;
+        text-style: bold;
     }
     """
 
@@ -53,9 +64,34 @@ class TaskDetailScreen(Screen[None]):
                 f"#{self._task_item.number} — {self._task_item.title}",
                 classes="task-screen-title",
             )
-            yield Static(_format_meta(self._task_item, self._details), classes="task-screen-meta")
-            yield Markdown(_body_text(self._details))
+            yield Static(
+                _format_meta(self._task_item, self._details),
+                id="task-screen-meta",
+                classes="task-screen-meta",
+            )
+            yield Markdown(_body_text(self._details), id="task-screen-body-md")
         yield Footer()
+
+    def set_details(self, details: TaskDetailData) -> None:
+        """Swap in fetched body + metadata (called after lazy load)."""
+        self._details = details
+        try:
+            self.query_one("#task-screen-meta", Static).update(
+                _format_meta(self._task_item, details)
+            )
+            self.query_one("#task-screen-body-md", Markdown).update(
+                _body_text(details)
+            )
+        except NoMatches:
+            return
+
+    def set_error(self, message: str) -> None:
+        """Show a fetch error in place of the body."""
+        try:
+            md = self.query_one("#task-screen-body-md", Markdown)
+        except NoMatches:
+            return
+        md.update(f"**Failed to load details:** {message}")
 
 
 def _body_text(details: TaskDetailData | None) -> str:

--- a/src/toad/screens/task_detail_screen.py
+++ b/src/toad/screens/task_detail_screen.py
@@ -1,0 +1,84 @@
+"""Full-screen drill-down for a single task.
+
+Pushed via ``app.push_screen`` from :class:`toad.widgets.task_detail.TaskDetail`
+when the user activates the "View comments" action. Escape pops back to
+the list.
+"""
+
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import VerticalScroll
+from textual.screen import Screen
+from textual.widgets import Footer, Header, Markdown, Static
+
+from toad.widgets.github_views.task_provider import TaskDetailData, TaskItem
+
+
+class TaskDetailScreen(Screen[None]):
+    """Full-screen task detail with Escape-to-pop."""
+
+    BINDINGS = [
+        Binding("escape", "app.pop_screen", "Back"),
+    ]
+
+    DEFAULT_CSS = """
+    TaskDetailScreen #task-screen-body {
+        padding: 1 2;
+    }
+    TaskDetailScreen .task-screen-title {
+        text-style: bold;
+        padding-bottom: 1;
+    }
+    TaskDetailScreen .task-screen-meta {
+        color: $text-muted;
+        padding-bottom: 1;
+    }
+    """
+
+    def __init__(
+        self,
+        task: TaskItem,
+        details: TaskDetailData | None = None,
+    ) -> None:
+        super().__init__()
+        self._task_item = task
+        self._details = details
+
+    def compose(self) -> ComposeResult:
+        yield Header(show_clock=False)
+        with VerticalScroll(id="task-screen-body"):
+            yield Static(
+                f"#{self._task_item.number} — {self._task_item.title}",
+                classes="task-screen-title",
+            )
+            yield Static(_format_meta(self._task_item, self._details), classes="task-screen-meta")
+            yield Markdown(_body_text(self._details))
+        yield Footer()
+
+
+def _body_text(details: TaskDetailData | None) -> str:
+    if details is None or not details.body:
+        return "_(no description)_"
+    return details.body
+
+
+def _format_meta(task: TaskItem, details: TaskDetailData | None) -> str:
+    parts: list[str] = [f"status: {task.status.value}"]
+    if task.milestone_title:
+        parts.append(f"milestone: {task.milestone_title}")
+    if task.priority is not None:
+        parts.append(f"priority: {task.priority.value}")
+    if task.assignees:
+        parts.append(f"assignees: {', '.join(task.assignees)}")
+    comments = details.comments_count if details else task.comments_count
+    parts.append(f"comments: {comments}")
+    if details and details.linked_prs:
+        pr_refs = ", ".join(
+            f"#{pr.get('number')}" for pr in details.linked_prs if pr.get("number")
+        )
+        parts.append(f"linked PRs: {pr_refs}")
+    if task.url:
+        parts.append(task.url)
+    return "  ·  ".join(parts)

--- a/src/toad/widgets/filter_toolbar.py
+++ b/src/toad/widgets/filter_toolbar.py
@@ -15,8 +15,9 @@ from typing import Iterable
 
 from textual.app import ComposeResult
 from textual.containers import Horizontal
+from textual.css.query import NoMatches
 from textual.message import Message
-from textual.widgets import Button, Select
+from textual.widgets import Button, Input, Select
 
 from toad.widgets.github_views.task_provider import TaskItem
 from toad.widgets.github_views.timeline_provider import ItemStatus, Priority
@@ -45,8 +46,10 @@ def filter_tasks(
     status: ItemStatus | None = None,
     milestone_id: str | None = None,
     priority: Priority | None = None,
+    title_query: str | None = None,
 ) -> list[TaskItem]:
     """Return the subset of ``tasks`` matching all non-None filters."""
+    query = (title_query or "").strip().lower() or None
     result: list[TaskItem] = []
     for task in tasks:
         if status is not None and task.status is not status:
@@ -54,6 +57,8 @@ def filter_tasks(
         if milestone_id is not None and task.milestone_id != milestone_id:
             continue
         if priority is not None and task.priority is not priority:
+            continue
+        if query is not None and query not in task.title.lower():
             continue
         result.append(task)
     return result
@@ -66,6 +71,7 @@ class FilterState:
     status: ItemStatus | None = None
     milestone_id: str | None = None
     priority: Priority | None = None
+    title_query: str | None = None
 
 
 class FilterToolbar(Horizontal):
@@ -77,6 +83,10 @@ class FilterToolbar(Horizontal):
         padding: 0 1;
     }
     FilterToolbar > Select {
+        width: 1fr;
+        margin-right: 1;
+    }
+    FilterToolbar > Input {
         width: 1fr;
         margin-right: 1;
     }
@@ -123,23 +133,39 @@ class FilterToolbar(Horizontal):
             allow_blank=False,
             id="filter-priority",
         )
+        yield Input(
+            placeholder="Filter title… (press / to focus)",
+            id="filter-title",
+        )
         yield Button("Refresh", id="filter-refresh", variant="primary")
 
     def set_milestones(self, milestones: Iterable[tuple[str, str]]) -> None:
-        """Replace the milestone dropdown's options while preserving selection."""
+        """Replace the milestone dropdown's options while preserving selection.
+
+        Suppresses ``Select.Changed`` during the swap so programmatic option
+        resets don't masquerade as user input.
+        """
         self._milestones = list(milestones)
         try:
             select = self.query_one("#filter-milestone", Select)
-        except Exception:
+        except NoMatches:
             return
         current = select.value
-        select.set_options(self._milestone_options())
-        if current != Select.BLANK and current in {
-            v for _, v in self._milestone_options()
-        }:
-            select.value = current
-        else:
-            select.value = _ANY
+        with self.prevent(Select.Changed):
+            select.set_options(self._milestone_options())
+            if current != Select.BLANK and current in {
+                v for _, v in self._milestone_options()
+            }:
+                select.value = current
+            else:
+                select.value = _ANY
+
+    def focus_title_input(self) -> None:
+        """Move focus to the title-query input (called by ``/`` binding)."""
+        try:
+            self.query_one("#filter-title", Input).focus()
+        except NoMatches:
+            return
 
     def current_state(self) -> FilterState:
         """Read the current filter selections."""
@@ -147,9 +173,16 @@ class FilterToolbar(Horizontal):
             status=_to_status(self._value("#filter-status")),
             milestone_id=_to_milestone(self._value("#filter-milestone")),
             priority=_to_priority(self._value("#filter-priority")),
+            title_query=self._title_query(),
         )
 
     def on_select_changed(self, event: Select.Changed) -> None:
+        event.stop()
+        self.post_message(self.FiltersChanged(self.current_state()))
+
+    def on_input_changed(self, event: Input.Changed) -> None:
+        if event.input.id != "filter-title":
+            return
         event.stop()
         self.post_message(self.FiltersChanged(self.current_state()))
 
@@ -164,12 +197,20 @@ class FilterToolbar(Horizontal):
     def _value(self, selector: str) -> str | None:
         try:
             select = self.query_one(selector, Select)
-        except Exception:
+        except NoMatches:
             return None
         value = select.value
         if value == Select.BLANK:
             return None
         return str(value)
+
+    def _title_query(self) -> str | None:
+        try:
+            query = self.query_one("#filter-title", Input).value
+        except NoMatches:
+            return None
+        query = query.strip()
+        return query or None
 
 
 def _to_status(raw: str | None) -> ItemStatus | None:

--- a/src/toad/widgets/filter_toolbar.py
+++ b/src/toad/widgets/filter_toolbar.py
@@ -1,0 +1,196 @@
+"""FilterToolbar — status/milestone/priority selects + refresh button.
+
+Posts a :class:`FilterToolbar.FiltersChanged` message whenever a selection
+changes, and :class:`FilterToolbar.RefreshRequested` when the refresh
+button is pressed.
+
+Also exposes a module-level :func:`filter_tasks` predicate used both by the
+Tasks pane and by unit tests.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+from textual.app import ComposeResult
+from textual.containers import Horizontal
+from textual.message import Message
+from textual.widgets import Button, Select
+
+from toad.widgets.github_views.task_provider import TaskItem
+from toad.widgets.github_views.timeline_provider import ItemStatus, Priority
+
+_ANY = "__any__"
+
+_STATUS_OPTIONS: tuple[tuple[str, str], ...] = (
+    ("All statuses", _ANY),
+    ("Todo", ItemStatus.TODO.value),
+    ("In progress", ItemStatus.IN_PROGRESS.value),
+    ("Done", ItemStatus.DONE.value),
+)
+
+_PRIORITY_OPTIONS: tuple[tuple[str, str], ...] = (
+    ("All priorities", _ANY),
+    ("P1", "1"),
+    ("P2", "2"),
+    ("P3", "3"),
+    ("P4", "4"),
+)
+
+
+def filter_tasks(
+    tasks: Iterable[TaskItem],
+    *,
+    status: ItemStatus | None = None,
+    milestone_id: str | None = None,
+    priority: Priority | None = None,
+) -> list[TaskItem]:
+    """Return the subset of ``tasks`` matching all non-None filters."""
+    result: list[TaskItem] = []
+    for task in tasks:
+        if status is not None and task.status is not status:
+            continue
+        if milestone_id is not None and task.milestone_id != milestone_id:
+            continue
+        if priority is not None and task.priority is not priority:
+            continue
+        result.append(task)
+    return result
+
+
+@dataclass(frozen=True)
+class FilterState:
+    """Snapshot of the toolbar's current filter selections."""
+
+    status: ItemStatus | None = None
+    milestone_id: str | None = None
+    priority: Priority | None = None
+
+
+class FilterToolbar(Horizontal):
+    """Horizontal row of filter selects plus a refresh button."""
+
+    DEFAULT_CSS = """
+    FilterToolbar {
+        height: auto;
+        padding: 0 1;
+    }
+    FilterToolbar > Select {
+        width: 1fr;
+        margin-right: 1;
+    }
+    FilterToolbar > Button {
+        width: auto;
+    }
+    """
+
+    class FiltersChanged(Message):
+        """Emitted when any select value changes."""
+
+        def __init__(self, state: FilterState) -> None:
+            super().__init__()
+            self.state = state
+
+    class RefreshRequested(Message):
+        """Emitted when the refresh button is pressed."""
+
+    def __init__(
+        self,
+        milestones: Iterable[tuple[str, str]] = (),
+        *,
+        id: str | None = None,
+    ) -> None:
+        super().__init__(id=id)
+        self._milestones: list[tuple[str, str]] = list(milestones)
+
+    def compose(self) -> ComposeResult:
+        yield Select(
+            options=list(_STATUS_OPTIONS),
+            value=_ANY,
+            allow_blank=False,
+            id="filter-status",
+        )
+        yield Select(
+            options=self._milestone_options(),
+            value=_ANY,
+            allow_blank=False,
+            id="filter-milestone",
+        )
+        yield Select(
+            options=list(_PRIORITY_OPTIONS),
+            value=_ANY,
+            allow_blank=False,
+            id="filter-priority",
+        )
+        yield Button("Refresh", id="filter-refresh", variant="primary")
+
+    def set_milestones(self, milestones: Iterable[tuple[str, str]]) -> None:
+        """Replace the milestone dropdown's options while preserving selection."""
+        self._milestones = list(milestones)
+        try:
+            select = self.query_one("#filter-milestone", Select)
+        except Exception:
+            return
+        current = select.value
+        select.set_options(self._milestone_options())
+        if current != Select.BLANK and current in {
+            v for _, v in self._milestone_options()
+        }:
+            select.value = current
+        else:
+            select.value = _ANY
+
+    def current_state(self) -> FilterState:
+        """Read the current filter selections."""
+        return FilterState(
+            status=_to_status(self._value("#filter-status")),
+            milestone_id=_to_milestone(self._value("#filter-milestone")),
+            priority=_to_priority(self._value("#filter-priority")),
+        )
+
+    def on_select_changed(self, event: Select.Changed) -> None:
+        event.stop()
+        self.post_message(self.FiltersChanged(self.current_state()))
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "filter-refresh":
+            event.stop()
+            self.post_message(self.RefreshRequested())
+
+    def _milestone_options(self) -> list[tuple[str, str]]:
+        return [("All milestones", _ANY), *self._milestones]
+
+    def _value(self, selector: str) -> str | None:
+        try:
+            select = self.query_one(selector, Select)
+        except Exception:
+            return None
+        value = select.value
+        if value == Select.BLANK:
+            return None
+        return str(value)
+
+
+def _to_status(raw: str | None) -> ItemStatus | None:
+    if raw is None or raw == _ANY:
+        return None
+    try:
+        return ItemStatus(raw)
+    except ValueError:
+        return None
+
+
+def _to_priority(raw: str | None) -> Priority | None:
+    if raw is None or raw == _ANY:
+        return None
+    try:
+        return Priority(int(raw))
+    except (ValueError, TypeError):
+        return None
+
+
+def _to_milestone(raw: str | None) -> str | None:
+    if raw is None or raw == _ANY:
+        return None
+    return raw

--- a/src/toad/widgets/github_views/github_timeline_provider.py
+++ b/src/toad/widgets/github_views/github_timeline_provider.py
@@ -272,6 +272,27 @@ class GitHubTimelineProvider:
         self._cached_fields = fields
         return fields
 
+    async def fetch_task_details(
+        self, issue_number: int
+    ) -> dict[str, Any]:
+        """Fetch body, comments, labels, assignees, and linked PRs for an issue.
+
+        Returns the raw ``gh issue view --json`` payload so callers can
+        decide how to render it. Kept on the timeline provider so callers
+        with a single provider handle can still drill into issue details.
+        """
+        raw = await _run_gh(
+            "issue",
+            "view",
+            str(issue_number),
+            "--repo",
+            self._repo,
+            "--json",
+            "number,body,comments,labels,assignees,url,closedByPullRequestsReferences",
+        )
+        result: dict[str, Any] = json.loads(raw)
+        return result
+
     async def _fetch_issues_and_project(
         self,
     ) -> tuple[list[dict[str, Any]], dict[str, Any]]:

--- a/src/toad/widgets/github_views/task_provider.py
+++ b/src/toad/widgets/github_views/task_provider.py
@@ -1,0 +1,259 @@
+"""TaskProvider — fetches project-board tasks (issues) with rich metadata.
+
+Kept separate from ``TimelineProvider`` so the timeline data path stays
+stable. ``TaskItem`` is a richer superset of ``ProviderItem`` used by the
+interactive Tasks widget (body, comments, linked PRs, assignees).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from dataclasses import dataclass, field
+from datetime import date, datetime
+from typing import Any, Protocol, runtime_checkable
+
+from toad.widgets.github_views.fetch import _run_gh
+from toad.widgets.github_views.github_timeline_provider import (
+    _PROJECT_ITEMS_QUERY,
+    _normalize_status,
+    _parse_date,
+    _parse_priority,
+    _parse_risk_labels,
+)
+from toad.widgets.github_views.timeline_provider import ItemStatus, Priority
+
+log = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class TaskItem:
+    """A project-board task with full metadata for the Tasks widget.
+
+    Superset of ``ProviderItem`` including fields only required by the
+    interactive list and detail views.
+    """
+
+    id: str
+    number: int
+    title: str
+    status: ItemStatus
+    milestone_id: str | None = None
+    milestone_title: str = ""
+    priority: Priority | None = None
+    assignees: list[str] = field(default_factory=list)
+    effort: str | None = None
+    labels: list[str] = field(default_factory=list)
+    risk_labels: list[str] = field(default_factory=list)
+    start_date: date | None = None
+    target_date: date | None = None
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+    comments_count: int = 0
+    url: str = ""
+    state: str = "open"
+
+
+@dataclass(frozen=True)
+class TaskDetailData:
+    """Lazy-loaded detail payload for a single task."""
+
+    number: int
+    body: str = ""
+    comments_count: int = 0
+    linked_prs: list[dict[str, Any]] = field(default_factory=list)
+    labels: list[str] = field(default_factory=list)
+    assignees: list[str] = field(default_factory=list)
+    url: str = ""
+
+
+def _parse_datetime(value: str | None) -> datetime | None:
+    """Parse an ISO-8601 datetime (with trailing Z) into a datetime."""
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        log.debug("unparseable datetime: %s", value)
+        return None
+
+
+@runtime_checkable
+class TaskProviderProtocol(Protocol):
+    """Minimal protocol implemented by ``TaskProvider``."""
+
+    async def fetch_tasks(self) -> list[TaskItem]: ...
+
+    async def fetch_task_details(self, issue_number: int) -> TaskDetailData: ...
+
+
+class TaskProvider:
+    """Fetches project-board tasks from GitHub via ``gh`` CLI.
+
+    Args:
+        repo: Owner/repo string (e.g. ``"DEGAorg/claude-code-config"``).
+        project_number: GitHub Projects V2 board number.
+    """
+
+    def __init__(self, repo: str, project_number: int) -> None:
+        if "/" not in repo:
+            msg = f"repo must be owner/name, got: {repo!r}"
+            raise ValueError(msg)
+        self._repo = repo
+        self._owner = repo.split("/", 1)[0]
+        self._project_number = project_number
+
+    async def fetch_tasks(self) -> list[TaskItem]:
+        """Fetch every project-board issue enriched with board fields."""
+        issues_task = asyncio.create_task(self._fetch_issues())
+        project_task = asyncio.create_task(self._fetch_project_data())
+        issues, project = await asyncio.gather(issues_task, project_task)
+        board_map = _build_board_map(project)
+
+        tasks: list[TaskItem] = []
+        for issue in issues:
+            number = issue.get("number", 0)
+            labels = [lbl.get("name", "") for lbl in issue.get("labels", [])]
+            board = board_map.get(number, {})
+
+            status = _normalize_status(board.get("Status"))
+            if not board.get("Status") and issue.get("state", "").lower() == "closed":
+                status = ItemStatus.DONE
+
+            milestone_data = issue.get("milestone") or {}
+            milestone_id = (
+                str(milestone_data.get("number"))
+                if milestone_data.get("number") is not None
+                else None
+            )
+            milestone_title = milestone_data.get("title", "") or ""
+
+            assignees = [
+                a.get("login", "") for a in issue.get("assignees", []) if a
+            ]
+
+            tasks.append(
+                TaskItem(
+                    id=str(number),
+                    number=number,
+                    title=issue.get("title", ""),
+                    status=status,
+                    milestone_id=milestone_id,
+                    milestone_title=milestone_title,
+                    priority=_parse_priority(labels),
+                    assignees=assignees,
+                    effort=board.get("Effort"),
+                    labels=labels,
+                    risk_labels=_parse_risk_labels(labels),
+                    start_date=_parse_date(board.get("Start Date")),
+                    target_date=_parse_date(board.get("Target Date")),
+                    created_at=_parse_datetime(issue.get("createdAt")),
+                    updated_at=_parse_datetime(issue.get("updatedAt")),
+                    comments_count=int(issue.get("comments", 0) or 0),
+                    url=issue.get("url", ""),
+                    state=issue.get("state", "open").lower(),
+                )
+            )
+        return tasks
+
+    async def fetch_task_details(self, issue_number: int) -> TaskDetailData:
+        """Fetch body, comments, and linked PRs for a single issue."""
+        raw = await _run_gh(
+            "issue",
+            "view",
+            str(issue_number),
+            "--repo",
+            self._repo,
+            "--json",
+            "number,body,comments,labels,assignees,url,closedByPullRequestsReferences",
+        )
+        data: dict[str, Any] = json.loads(raw)
+        comments = data.get("comments") or []
+        linked = data.get("closedByPullRequestsReferences") or []
+        return TaskDetailData(
+            number=int(data.get("number", issue_number)),
+            body=data.get("body", "") or "",
+            comments_count=len(comments),
+            linked_prs=list(linked),
+            labels=[lbl.get("name", "") for lbl in data.get("labels", [])],
+            assignees=[
+                a.get("login", "") for a in data.get("assignees", []) if a
+            ],
+            url=data.get("url", ""),
+        )
+
+    async def _fetch_issues(self) -> list[dict[str, Any]]:
+        raw = await _run_gh(
+            "issue",
+            "list",
+            "--repo",
+            self._repo,
+            "--state",
+            "all",
+            "--json",
+            "number,title,state,labels,createdAt,updatedAt,milestone,url,assignees,comments",
+            "--limit",
+            "200",
+        )
+        result: list[dict[str, Any]] = json.loads(raw)
+        return result
+
+    async def _fetch_project_data(self) -> dict[str, Any]:
+        raw = await _run_gh(
+            "api",
+            "graphql",
+            "-f",
+            f"owner={self._owner}",
+            "-F",
+            f"number={self._project_number}",
+            "-f",
+            f"query={_PROJECT_ITEMS_QUERY}",
+            timeout_s=30,
+        )
+        result: dict[str, Any] = json.loads(raw)
+        return result
+
+
+def _build_board_map(
+    project_data: dict[str, Any],
+) -> dict[int, dict[str, str]]:
+    """Flatten GraphQL project data to issue_number -> {field: value}."""
+    project = (
+        project_data.get("data", {})
+        .get("organization", {})
+        .get("projectV2", {})
+    )
+    items = project.get("items", {}).get("nodes", [])
+    board_map: dict[int, dict[str, str]] = {}
+    for item in items:
+        if not item:
+            continue
+        content = item.get("content")
+        if not content or "number" not in content:
+            continue
+        number = content["number"]
+        fields: dict[str, str] = {}
+        for fv in item.get("fieldValues", {}).get("nodes", []):
+            if not fv:
+                continue
+            field_name = (fv.get("field") or {}).get("name", "")
+            if not field_name:
+                continue
+            value = (
+                fv.get("text")
+                or fv.get("name")
+                or fv.get("title")
+                or fv.get("date")
+            )
+            if fv.get("number") is not None and value is None:
+                value = str(fv["number"])
+            if value is not None:
+                fields[field_name] = str(value)
+        board_map[number] = fields
+    return board_map
+
+
+assert isinstance(
+    TaskProvider.__new__(TaskProvider), TaskProviderProtocol
+), "TaskProvider does not satisfy TaskProviderProtocol"

--- a/src/toad/widgets/github_views/task_provider.py
+++ b/src/toad/widgets/github_views/task_provider.py
@@ -68,6 +68,22 @@ class TaskDetailData:
     url: str = ""
 
 
+def _comments_count(value: Any) -> int:
+    """Parse a ``comments`` field which may be an int or a list of comment dicts.
+
+    ``gh issue list --json comments`` returns the full comment list; older
+    call sites return an integer count. Handle both defensively.
+    """
+    if value is None:
+        return 0
+    if isinstance(value, list):
+        return len(value)
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
 def _parse_datetime(value: str | None) -> datetime | None:
     """Parse an ISO-8601 datetime (with trailing Z) into a datetime."""
     if not value:
@@ -150,7 +166,7 @@ class TaskProvider:
                     target_date=_parse_date(board.get("Target Date")),
                     created_at=_parse_datetime(issue.get("createdAt")),
                     updated_at=_parse_datetime(issue.get("updatedAt")),
-                    comments_count=int(issue.get("comments", 0) or 0),
+                    comments_count=_comments_count(issue.get("comments")),
                     url=issue.get("url", ""),
                     state=issue.get("state", "open").lower(),
                 )

--- a/src/toad/widgets/project_state_pane.py
+++ b/src/toad/widgets/project_state_pane.py
@@ -13,16 +13,20 @@ from textual.app import ComposeResult
 from textual.containers import Horizontal, Vertical
 from textual.message import Message
 from textual.timer import Timer
-from textual.widgets import Button, TabbedContent, TabPane
+from textual.widgets import Button, DataTable, TabbedContent, TabPane
 
 from toad.widgets.builder_view import BuilderView
 from toad.widgets.canon_state import CanonStateWidget
+from toad.widgets.filter_toolbar import FilterToolbar, FilterState, filter_tasks
 from toad.widgets.gantt_timeline import GanttTimeline
 from toad.widgets.github_state import GitHubStateWidget
 from toad.widgets.github_views.github_timeline_provider import (
     GitHubTimelineProvider,
 )
+from toad.widgets.github_views.task_provider import TaskItem, TaskProvider
 from toad.widgets.github_views.timeline_data import build_timeline
+from toad.widgets.task_detail import TaskDetail
+from toad.widgets.task_table import TaskTable
 
 log = logging.getLogger(__name__)
 
@@ -121,6 +125,18 @@ class ProjectStatePane(Vertical):
         padding: 0 1;
     }
 
+    ProjectStatePane #tasks-body {
+        height: 1fr;
+    }
+
+    ProjectStatePane #task-table {
+        width: 3fr;
+    }
+
+    ProjectStatePane #task-detail {
+        width: 2fr;
+    }
+
     ProjectStatePane .empty-state {
         color: $text-muted;
         text-style: italic;
@@ -139,7 +155,11 @@ class ProjectStatePane(Vertical):
         super().__init__(**kwargs)
         self._project_path = project_path or Path(".").resolve()
         self._refresh_timer: Timer | None = None
+        self._tasks_refresh_timer: Timer | None = None
         self._provider = self._make_provider()
+        self._task_provider = self._make_task_provider()
+        self._all_tasks: list[TaskItem] = []
+        self._filter_state = FilterState()
 
     def compose(self) -> ComposeResult:
         # Toolbar with one button per section
@@ -159,6 +179,11 @@ class ProjectStatePane(Vertical):
                 )
             with TabPane("Timeline", id="tab-timeline"):
                 yield GanttTimeline(id="pane-gantt")
+            with TabPane("Tasks", id="tab-tasks"):
+                yield FilterToolbar(id="task-filter-toolbar")
+                with Horizontal(id="tasks-body"):
+                    yield TaskTable(id="task-table")
+                    yield TaskDetail(id="task-detail")
 
         # Canon state watcher (invisible, drives State view)
         yield CanonStateWidget(
@@ -177,6 +202,7 @@ class ProjectStatePane(Vertical):
         self.query_one(f"#{SECTION_STATE}").display = False
         self._sync_toolbar()
         self._fetch_timeline()
+        self._fetch_tasks()
 
     def watch_display(self, visible: bool) -> None:
         """Stop timer when entire pane is hidden."""
@@ -200,6 +226,17 @@ class ProjectStatePane(Vertical):
         if self._refresh_timer is not None:
             self._refresh_timer.stop()
             self._refresh_timer = None
+
+    @on(TabbedContent.TabActivated, f"#{SECTION_PLANNING}")
+    def _on_planning_tab_activated(
+        self, event: TabbedContent.TabActivated
+    ) -> None:
+        active = event.tabbed_content.active
+        if active == "tab-tasks":
+            self._fetch_tasks()
+            self._start_tasks_timer()
+        else:
+            self._stop_tasks_timer()
 
     # ------------------------------------------------------------------
     # Toolbar — generic button handler
@@ -308,3 +345,106 @@ class ProjectStatePane(Vertical):
     def refresh_timeline(self) -> None:
         """Re-fetch timeline data. Called via socket controller."""
         self._fetch_timeline()
+
+    # ------------------------------------------------------------------
+    # Tasks — provider → filter → table → detail
+    # ------------------------------------------------------------------
+
+    def _make_task_provider(self) -> TaskProvider | None:
+        cfg = _read_timeline_config(self._project_path)
+        if cfg is None:
+            return None
+        return TaskProvider(
+            repo=cfg["repo"],
+            project_number=cfg["project_number"],
+        )
+
+    @work(exclusive=True, exit_on_error=False, group="fetch-tasks")
+    async def _fetch_tasks(self) -> None:
+        if self._task_provider is None:
+            return
+        try:
+            tasks = await self._task_provider.fetch_tasks()
+        except Exception as exc:
+            log.warning("Task fetch failed: %s", exc)
+            return
+        self._all_tasks = tasks
+        self._sync_milestone_options(tasks)
+        self._apply_filters()
+
+    def _sync_milestone_options(self, tasks: list[TaskItem]) -> None:
+        seen: dict[str, str] = {}
+        for task in tasks:
+            if task.milestone_id and task.milestone_id not in seen:
+                seen[task.milestone_id] = task.milestone_title or task.milestone_id
+        try:
+            toolbar = self.query_one("#task-filter-toolbar", FilterToolbar)
+        except Exception:
+            return
+        toolbar.set_milestones([(title, mid) for mid, title in seen.items()])
+
+    def _apply_filters(self) -> None:
+        filtered = filter_tasks(
+            self._all_tasks,
+            status=self._filter_state.status,
+            milestone_id=self._filter_state.milestone_id,
+            priority=self._filter_state.priority,
+        )
+        try:
+            table = self.query_one("#task-table", TaskTable)
+        except Exception:
+            return
+        table.set_tasks(filtered)
+
+    @on(FilterToolbar.FiltersChanged)
+    def _on_filters_changed(self, event: FilterToolbar.FiltersChanged) -> None:
+        event.stop()
+        self._filter_state = event.state
+        self._apply_filters()
+
+    @on(FilterToolbar.RefreshRequested)
+    def _on_tasks_refresh_requested(
+        self, event: FilterToolbar.RefreshRequested
+    ) -> None:
+        event.stop()
+        self._fetch_tasks()
+
+    @on(DataTable.RowSelected, "#task-table")
+    def _on_task_row_selected(self, event: DataTable.RowSelected) -> None:
+        event.stop()
+        key = event.row_key.value
+        if key is None:
+            return
+        table = self.query_one("#task-table", TaskTable)
+        task = table.get_task(str(key))
+        if task is None:
+            return
+        detail = self.query_one("#task-detail", TaskDetail)
+        detail.show_task(task)
+        self._fetch_task_details(task.number)
+
+    @work(exclusive=True, exit_on_error=False, group="fetch-task-details")
+    async def _fetch_task_details(self, number: int) -> None:
+        if self._task_provider is None:
+            return
+        try:
+            details = await self._task_provider.fetch_task_details(number)
+        except Exception as exc:
+            log.warning("Task detail fetch failed for #%s: %s", number, exc)
+            return
+        try:
+            detail = self.query_one("#task-detail", TaskDetail)
+        except Exception:
+            return
+        detail.show_details(details)
+
+    def _start_tasks_timer(self) -> None:
+        if self._tasks_refresh_timer is None:
+            self._tasks_refresh_timer = self.set_interval(
+                self.REFRESH_INTERVAL, self._fetch_tasks
+            )
+
+    def _stop_tasks_timer(self) -> None:
+        if self._tasks_refresh_timer is not None:
+            self._tasks_refresh_timer.stop()
+            self._tasks_refresh_timer = None

--- a/src/toad/widgets/project_state_pane.py
+++ b/src/toad/widgets/project_state_pane.py
@@ -10,10 +10,12 @@ from typing import Any
 import yaml
 from textual import on, work
 from textual.app import ComposeResult
+from textual.binding import Binding
 from textual.containers import Horizontal, Vertical
+from textual.css.query import NoMatches
 from textual.message import Message
 from textual.timer import Timer
-from textual.widgets import Button, DataTable, TabbedContent, TabPane
+from textual.widgets import Button, DataTable, Static, TabbedContent, TabPane
 
 from toad.widgets.builder_view import BuilderView
 from toad.widgets.canon_state import CanonStateWidget
@@ -89,6 +91,11 @@ class ProjectStatePane(Vertical):
     class AllSectionsHidden(Message):
         """Posted when every section is hidden — pane should close."""
 
+    BINDINGS = [
+        Binding("r", "refresh_tasks", "Refresh tasks", show=False),
+        Binding("slash", "focus_task_filter", "Filter tasks", show=False),
+    ]
+
     DEFAULT_CSS = """
     ProjectStatePane {
         display: none;
@@ -137,6 +144,18 @@ class ProjectStatePane(Vertical):
         width: 2fr;
     }
 
+    ProjectStatePane #tasks-status {
+        height: auto;
+        padding: 0 1;
+        color: $text-muted;
+        text-style: italic;
+    }
+
+    ProjectStatePane #tasks-status.error {
+        color: $error;
+        text-style: bold;
+    }
+
     ProjectStatePane .empty-state {
         color: $text-muted;
         text-style: italic;
@@ -181,6 +200,7 @@ class ProjectStatePane(Vertical):
                 yield GanttTimeline(id="pane-gantt")
             with TabPane("Tasks", id="tab-tasks"):
                 yield FilterToolbar(id="task-filter-toolbar")
+                yield Static("", id="tasks-status")
                 with Horizontal(id="tasks-body"):
                     yield TaskTable(id="task-table")
                     yield TaskDetail(id="task-detail")
@@ -205,9 +225,10 @@ class ProjectStatePane(Vertical):
         self._fetch_tasks()
 
     def watch_display(self, visible: bool) -> None:
-        """Stop timer when entire pane is hidden."""
+        """Stop timers when entire pane is hidden."""
         if not visible:
             self._stop_timeline_timer()
+            self._stop_tasks_timer()
 
     def _sync_timeline_timer(self, section_id: str, *, visible: bool) -> None:
         """Start/stop the refresh timer when the GitHub section toggles."""
@@ -362,15 +383,30 @@ class ProjectStatePane(Vertical):
     @work(exclusive=True, exit_on_error=False, group="fetch-tasks")
     async def _fetch_tasks(self) -> None:
         if self._task_provider is None:
+            self._set_tasks_status("No task provider configured.", error=True)
             return
+        self._set_tasks_status("Loading tasks…")
         try:
             tasks = await self._task_provider.fetch_tasks()
         except Exception as exc:
             log.warning("Task fetch failed: %s", exc)
+            self._set_tasks_status(f"Task fetch failed: {exc}", error=True)
             return
         self._all_tasks = tasks
         self._sync_milestone_options(tasks)
         self._apply_filters()
+
+    def _set_tasks_status(self, message: str, *, error: bool = False) -> None:
+        """Update the inline status label above the table."""
+        try:
+            label = self.query_one("#tasks-status", Static)
+        except NoMatches:
+            return
+        label.update(message)
+        if error:
+            label.add_class("error")
+        else:
+            label.remove_class("error")
 
     def _sync_milestone_options(self, tasks: list[TaskItem]) -> None:
         seen: dict[str, str] = {}
@@ -379,7 +415,7 @@ class ProjectStatePane(Vertical):
                 seen[task.milestone_id] = task.milestone_title or task.milestone_id
         try:
             toolbar = self.query_one("#task-filter-toolbar", FilterToolbar)
-        except Exception:
+        except NoMatches:
             return
         toolbar.set_milestones([(title, mid) for mid, title in seen.items()])
 
@@ -389,12 +425,25 @@ class ProjectStatePane(Vertical):
             status=self._filter_state.status,
             milestone_id=self._filter_state.milestone_id,
             priority=self._filter_state.priority,
+            title_query=self._filter_state.title_query,
         )
         try:
             table = self.query_one("#task-table", TaskTable)
-        except Exception:
+        except NoMatches:
             return
         table.set_tasks(filtered)
+        total = len(self._all_tasks)
+        shown = len(filtered)
+        if total == 0:
+            self._set_tasks_status("No tasks loaded.")
+        elif shown == 0:
+            self._set_tasks_status(
+                f"No tasks match filters ({total} total). Press r to refresh."
+            )
+        else:
+            self._set_tasks_status(
+                f"Showing {shown} of {total} tasks."
+            )
 
     @on(FilterToolbar.FiltersChanged)
     def _on_filters_changed(self, event: FilterToolbar.FiltersChanged) -> None:
@@ -408,6 +457,11 @@ class ProjectStatePane(Vertical):
     ) -> None:
         event.stop()
         self._fetch_tasks()
+
+    @on(TaskDetail.DrillDownRequested)
+    def _on_task_drill_down(self, event: TaskDetail.DrillDownRequested) -> None:
+        event.stop()
+        self.open_task_drill_down(event.task)
 
     @on(DataTable.RowSelected, "#task-table")
     def _on_task_row_selected(self, event: DataTable.RowSelected) -> None:
@@ -434,7 +488,7 @@ class ProjectStatePane(Vertical):
             return
         try:
             detail = self.query_one("#task-detail", TaskDetail)
-        except Exception:
+        except NoMatches:
             return
         detail.show_details(details)
 
@@ -448,3 +502,57 @@ class ProjectStatePane(Vertical):
         if self._tasks_refresh_timer is not None:
             self._tasks_refresh_timer.stop()
             self._tasks_refresh_timer = None
+
+    # ------------------------------------------------------------------
+    # Keybindings — active only while the Tasks tab is visible
+    # ------------------------------------------------------------------
+
+    def _is_tasks_tab_active(self) -> bool:
+        try:
+            tc = self.query_one(f"#{SECTION_PLANNING}", TabbedContent)
+        except NoMatches:
+            return False
+        return tc.display and tc.active == "tab-tasks"
+
+    def action_refresh_tasks(self) -> None:
+        if not self._is_tasks_tab_active():
+            return
+        self._fetch_tasks()
+
+    def action_focus_task_filter(self) -> None:
+        if not self._is_tasks_tab_active():
+            return
+        try:
+            toolbar = self.query_one("#task-filter-toolbar", FilterToolbar)
+        except NoMatches:
+            return
+        toolbar.focus_title_input()
+
+    # ------------------------------------------------------------------
+    # Drill-down — live-updating screen with lazy details
+    # ------------------------------------------------------------------
+
+    def open_task_drill_down(self, task: TaskItem) -> None:
+        """Push the full-screen task detail, fetching details into it live."""
+        # Lazy import — avoids cycle with ``toad.screens``.
+        from toad.screens.task_detail_screen import TaskDetailScreen
+
+        screen = TaskDetailScreen(task)
+        self.app.push_screen(screen)
+        self._fetch_task_details_into(task.number, screen)
+
+    @work(exclusive=True, exit_on_error=False, group="fetch-drill-details")
+    async def _fetch_task_details_into(
+        self,
+        number: int,
+        screen: Any,
+    ) -> None:
+        if self._task_provider is None:
+            return
+        try:
+            details = await self._task_provider.fetch_task_details(number)
+        except Exception as exc:
+            log.warning("Drill-down detail fetch failed for #%s: %s", number, exc)
+            screen.set_error(str(exc))
+            return
+        screen.set_details(details)

--- a/src/toad/widgets/task_detail.py
+++ b/src/toad/widgets/task_detail.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from textual.app import ComposeResult
 from textual.containers import Container, VerticalScroll
+from textual.message import Message
 from textual.widgets import Button, Collapsible, ContentSwitcher, Markdown, Static
 
 from toad.widgets.github_views.task_provider import TaskDetailData, TaskItem
@@ -54,6 +55,13 @@ class TaskDetail(Container):
         margin-top: 1;
     }
     """
+
+    class DrillDownRequested(Message):
+        """Emitted when the user activates "View comments"."""
+
+        def __init__(self, task: TaskItem) -> None:
+            super().__init__()
+            self.task = task
 
     def __init__(
         self,
@@ -125,11 +133,8 @@ class TaskDetail(Container):
             return
         if self._task_item is None:
             return
-        # Lazy import — avoids a cycle with ``toad.screens``.
-        from toad.screens.task_detail_screen import TaskDetailScreen
-
-        self.app.push_screen(TaskDetailScreen(self._task_item, self._details))
         event.stop()
+        self.post_message(self.DrillDownRequested(self._task_item))
 
 
 def _render_summary(task: TaskItem) -> str:

--- a/src/toad/widgets/task_detail.py
+++ b/src/toad/widgets/task_detail.py
@@ -1,0 +1,175 @@
+"""TaskDetail widget — ContentSwitcher between an empty state and task detail.
+
+Master-detail partner of :class:`toad.widgets.task_table.TaskTable`. The
+table calls :meth:`TaskDetail.show_task` on row selection to render the
+selected task's metadata immediately; body + comments are populated via
+:meth:`TaskDetail.show_details` once the async fetch completes.
+"""
+
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.containers import Container, VerticalScroll
+from textual.widgets import Button, Collapsible, ContentSwitcher, Markdown, Static
+
+from toad.widgets.github_views.task_provider import TaskDetailData, TaskItem
+
+_EMPTY_ID = "empty"
+_DETAIL_ID = "detail"
+
+
+class TaskDetail(Container):
+    """Detail pane for the Tasks widget.
+
+    Holds a :class:`ContentSwitcher` with two children:
+
+    * an empty-state placeholder shown before any row is selected,
+    * a detail view with the task title, rendered Markdown body, and a
+      :class:`Collapsible` metadata panel exposing labels, dates, linked
+      PRs, and a "View comments" button that pushes the drill-down
+      screen.
+    """
+
+    DEFAULT_CSS = """
+    TaskDetail {
+        height: 1fr;
+        width: 1fr;
+    }
+    TaskDetail ContentSwitcher {
+        height: 1fr;
+    }
+    TaskDetail #detail {
+        padding: 1 2;
+    }
+    TaskDetail .task-detail-title {
+        text-style: bold;
+        padding-bottom: 1;
+    }
+    TaskDetail .task-detail-empty {
+        content-align: center middle;
+        color: $text-muted;
+        height: 1fr;
+    }
+    TaskDetail Button {
+        margin-top: 1;
+    }
+    """
+
+    def __init__(
+        self,
+        *,
+        name: str | None = None,
+        id: str | None = None,
+        classes: str | None = None,
+    ) -> None:
+        super().__init__(name=name, id=id, classes=classes)
+        self._task: TaskItem | None = None
+        self._details: TaskDetailData | None = None
+
+    def compose(self) -> ComposeResult:
+        with ContentSwitcher(initial=_EMPTY_ID):
+            yield Static(
+                "Select a task to see details.",
+                id=_EMPTY_ID,
+                classes="task-detail-empty",
+            )
+            with VerticalScroll(id=_DETAIL_ID):
+                yield Static("", id="task-detail-title", classes="task-detail-title")
+                yield Static("", id="task-detail-summary")
+                yield Markdown("", id="task-detail-body")
+                with Collapsible(title="Metadata", id="task-detail-meta"):
+                    yield Static("", id="task-detail-meta-body")
+                yield Button(
+                    "View comments",
+                    id="task-detail-view-comments",
+                    variant="primary",
+                )
+
+    def show_task(self, task: TaskItem) -> None:
+        """Render immediate task metadata and switch to the detail view."""
+        self._task = task
+        self._details = None
+        self.query_one("#task-detail-title", Static).update(
+            f"#{task.number} — {task.title}"
+        )
+        self.query_one("#task-detail-summary", Static).update(
+            _render_summary(task)
+        )
+        self.query_one("#task-detail-body", Markdown).update(
+            "_Loading body…_"
+        )
+        self.query_one("#task-detail-meta-body", Static).update(
+            _render_meta(task, None)
+        )
+        self.query_one(ContentSwitcher).current = _DETAIL_ID
+
+    def show_details(self, details: TaskDetailData) -> None:
+        """Render the lazy-loaded body + linked PRs once available."""
+        self._details = details
+        self.query_one("#task-detail-body", Markdown).update(
+            details.body or "_(no description)_"
+        )
+        self.query_one("#task-detail-meta-body", Static).update(
+            _render_meta(self._task, details)
+        )
+
+    def clear(self) -> None:
+        """Reset back to the empty state."""
+        self._task = None
+        self._details = None
+        self.query_one(ContentSwitcher).current = _EMPTY_ID
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        """Drill into the full-screen detail view on "View comments"."""
+        if event.button.id != "task-detail-view-comments":
+            return
+        if self._task is None:
+            return
+        # Lazy import — avoids a cycle with ``toad.screens``.
+        from toad.screens.task_detail_screen import TaskDetailScreen
+
+        self.app.push_screen(TaskDetailScreen(self._task, self._details))
+        event.stop()
+
+
+def _render_summary(task: TaskItem) -> str:
+    """Short one-line metadata summary shown above the body."""
+    parts: list[str] = [f"status: {task.status.value}"]
+    if task.milestone_title:
+        parts.append(f"milestone: {task.milestone_title}")
+    if task.priority is not None:
+        parts.append(f"priority: {task.priority.value}")
+    if task.assignees:
+        parts.append(f"assignees: {', '.join(task.assignees)}")
+    if task.effort:
+        parts.append(f"effort: {task.effort}")
+    return "  ·  ".join(parts)
+
+
+def _render_meta(
+    task: TaskItem | None, details: TaskDetailData | None
+) -> str:
+    """Multi-line metadata block for the Collapsible panel."""
+    if task is None:
+        return ""
+    lines: list[str] = []
+    if task.labels:
+        lines.append(f"labels: {', '.join(task.labels)}")
+    if task.start_date:
+        lines.append(f"start: {task.start_date.isoformat()}")
+    if task.target_date:
+        lines.append(f"target: {task.target_date.isoformat()}")
+    if task.created_at:
+        lines.append(f"created: {task.created_at.date().isoformat()}")
+    if task.updated_at:
+        lines.append(f"updated: {task.updated_at.date().isoformat()}")
+    comments = details.comments_count if details else task.comments_count
+    lines.append(f"comments: {comments}")
+    if details and details.linked_prs:
+        pr_refs = ", ".join(
+            f"#{pr.get('number')}" for pr in details.linked_prs if pr.get("number")
+        )
+        lines.append(f"linked PRs: {pr_refs}")
+    if task.url:
+        lines.append(f"url: {task.url}")
+    return "\n".join(lines)

--- a/src/toad/widgets/task_detail.py
+++ b/src/toad/widgets/task_detail.py
@@ -63,7 +63,7 @@ class TaskDetail(Container):
         classes: str | None = None,
     ) -> None:
         super().__init__(name=name, id=id, classes=classes)
-        self._task: TaskItem | None = None
+        self._task_item: TaskItem | None = None
         self._details: TaskDetailData | None = None
 
     def compose(self) -> ComposeResult:
@@ -87,7 +87,7 @@ class TaskDetail(Container):
 
     def show_task(self, task: TaskItem) -> None:
         """Render immediate task metadata and switch to the detail view."""
-        self._task = task
+        self._task_item = task
         self._details = None
         self.query_one("#task-detail-title", Static).update(
             f"#{task.number} — {task.title}"
@@ -110,12 +110,12 @@ class TaskDetail(Container):
             details.body or "_(no description)_"
         )
         self.query_one("#task-detail-meta-body", Static).update(
-            _render_meta(self._task, details)
+            _render_meta(self._task_item, details)
         )
 
     def clear(self) -> None:
         """Reset back to the empty state."""
-        self._task = None
+        self._task_item = None
         self._details = None
         self.query_one(ContentSwitcher).current = _EMPTY_ID
 
@@ -123,12 +123,12 @@ class TaskDetail(Container):
         """Drill into the full-screen detail view on "View comments"."""
         if event.button.id != "task-detail-view-comments":
             return
-        if self._task is None:
+        if self._task_item is None:
             return
         # Lazy import — avoids a cycle with ``toad.screens``.
         from toad.screens.task_detail_screen import TaskDetailScreen
 
-        self.app.push_screen(TaskDetailScreen(self._task, self._details))
+        self.app.push_screen(TaskDetailScreen(self._task_item, self._details))
         event.stop()
 
 

--- a/src/toad/widgets/task_table.py
+++ b/src/toad/widgets/task_table.py
@@ -1,0 +1,107 @@
+"""TaskTable — DataTable master listing project-board tasks.
+
+Subclasses ``DataTable`` with ``cursor_type="row"``. Row keys are the
+``TaskItem.id`` string so selection events round-trip back to the
+owning task via ``event.row_key.value``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from textual.widgets import DataTable
+
+from toad.widgets.github_views.task_provider import TaskItem
+from toad.widgets.github_views.timeline_provider import ItemStatus, Priority
+
+_STATUS_LABELS: dict[ItemStatus, str] = {
+    ItemStatus.TODO: "Todo",
+    ItemStatus.IN_PROGRESS: "In Progress",
+    ItemStatus.DONE: "Done",
+}
+
+_PRIORITY_LABELS: dict[Priority, str] = {
+    Priority.P1: "P1",
+    Priority.P2: "P2",
+    Priority.P3: "P3",
+    Priority.P4: "P4",
+}
+
+_COLUMNS: tuple[str, ...] = (
+    "Status",
+    "Title",
+    "Milestone",
+    "Priority",
+    "Assignee",
+    "Effort",
+)
+
+
+def _format_status(status: ItemStatus) -> str:
+    return _STATUS_LABELS.get(status, status.value)
+
+
+def _format_priority(priority: Priority | None) -> str:
+    if priority is None:
+        return ""
+    return _PRIORITY_LABELS.get(priority, "")
+
+
+def _format_assignees(assignees: list[str]) -> str:
+    if not assignees:
+        return ""
+    if len(assignees) == 1:
+        return assignees[0]
+    return f"{assignees[0]} +{len(assignees) - 1}"
+
+
+def _truncate(text: str, max_len: int) -> str:
+    if len(text) <= max_len:
+        return text
+    return text[: max_len - 1] + "\u2026"
+
+
+class TaskTable(DataTable[str]):
+    """DataTable listing ``TaskItem`` rows keyed by issue id.
+
+    Uses built-in ``DataTable.RowSelected`` for selection — callers read
+    ``event.row_key.value`` to recover the ``TaskItem.id``.
+    """
+
+    DEFAULT_CSS = """
+    TaskTable {
+        height: 1fr;
+    }
+    """
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(zebra_stripes=True, **kwargs)
+        self.cursor_type = "row"
+        self._columns_added = False
+        self._tasks: dict[str, TaskItem] = {}
+
+    def _ensure_columns(self) -> None:
+        if self._columns_added:
+            return
+        self.add_columns(*_COLUMNS)
+        self._columns_added = True
+
+    def set_tasks(self, tasks: list[TaskItem]) -> None:
+        """Replace all rows with ``tasks``. Row keys = ``task.id``."""
+        self.clear()
+        self._ensure_columns()
+        self._tasks = {t.id: t for t in tasks}
+        for task in tasks:
+            self.add_row(
+                _format_status(task.status),
+                _truncate(task.title, 60),
+                task.milestone_title,
+                _format_priority(task.priority),
+                _format_assignees(task.assignees),
+                task.effort or "",
+                key=task.id,
+            )
+
+    def get_task(self, task_id: str) -> TaskItem | None:
+        """Return the ``TaskItem`` previously set for ``task_id``."""
+        return self._tasks.get(task_id)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,176 @@
+"""Shared fixtures for Tasks-widget tests.
+
+Provides mock ``gh`` CLI responses so ``TaskProvider`` tests stay offline
+and deterministic.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import date, datetime, timezone
+from typing import Any
+
+import pytest
+
+from toad.widgets.github_views.task_provider import TaskDetailData, TaskItem
+from toad.widgets.github_views.timeline_provider import ItemStatus, Priority
+
+
+@pytest.fixture
+def mock_issues_payload() -> str:
+    """Raw JSON string returned by ``gh issue list --json ...``."""
+    issues: list[dict[str, Any]] = [
+        {
+            "number": 101,
+            "title": "Wire Tasks tab",
+            "state": "OPEN",
+            "labels": [{"name": "p1"}, {"name": "risk:scope"}],
+            "createdAt": "2026-04-10T12:00:00Z",
+            "updatedAt": "2026-04-11T08:00:00Z",
+            "milestone": {"number": 1, "title": "M1 — UI"},
+            "url": "https://github.com/acme/proj/issues/101",
+            "assignees": [{"login": "alberto"}],
+            "comments": 4,
+        },
+        {
+            "number": 102,
+            "title": "Ship PM widget",
+            "state": "CLOSED",
+            "labels": [{"name": "p3"}],
+            "createdAt": "2026-04-01T09:00:00Z",
+            "updatedAt": "2026-04-12T10:00:00Z",
+            "milestone": None,
+            "url": "https://github.com/acme/proj/issues/102",
+            "assignees": [],
+            "comments": 0,
+        },
+    ]
+    return json.dumps(issues)
+
+
+@pytest.fixture
+def mock_project_payload() -> str:
+    """Raw JSON string returned by ``gh api graphql ...`` project query."""
+    data = {
+        "data": {
+            "organization": {
+                "projectV2": {
+                    "items": {
+                        "nodes": [
+                            {
+                                "content": {"number": 101},
+                                "fieldValues": {
+                                    "nodes": [
+                                        {
+                                            "field": {"name": "Status"},
+                                            "name": "In Progress",
+                                        },
+                                        {
+                                            "field": {"name": "Effort"},
+                                            "number": 2,
+                                        },
+                                        {
+                                            "field": {"name": "Start Date"},
+                                            "date": "2026-04-10",
+                                        },
+                                        {
+                                            "field": {"name": "Target Date"},
+                                            "date": "2026-04-18",
+                                        },
+                                    ]
+                                },
+                            },
+                            {
+                                "content": {"number": 102},
+                                "fieldValues": {"nodes": []},
+                            },
+                        ]
+                    }
+                }
+            }
+        }
+    }
+    return json.dumps(data)
+
+
+@pytest.fixture
+def mock_issue_detail_payload() -> str:
+    """Raw JSON returned by ``gh issue view <n> --json ...``."""
+    data = {
+        "number": 101,
+        "body": "## Heading\n\nBody text with **markdown**.",
+        "comments": [
+            {"author": {"login": "alice"}, "body": "+1"},
+            {"author": {"login": "bob"}, "body": "LGTM"},
+        ],
+        "labels": [{"name": "p1"}, {"name": "risk:scope"}],
+        "assignees": [{"login": "alberto"}],
+        "url": "https://github.com/acme/proj/issues/101",
+        "closedByPullRequestsReferences": [
+            {"number": 200, "url": "https://github.com/acme/proj/pull/200"},
+        ],
+    }
+    return json.dumps(data)
+
+
+@pytest.fixture
+def sample_tasks() -> list[TaskItem]:
+    """Deterministic list of ``TaskItem`` for widget tests."""
+    return [
+        TaskItem(
+            id="101",
+            number=101,
+            title="Wire Tasks tab",
+            status=ItemStatus.IN_PROGRESS,
+            milestone_id="1",
+            milestone_title="M1 — UI",
+            priority=Priority.P1,
+            assignees=["alberto"],
+            effort="2",
+            labels=["p1", "risk:scope"],
+            risk_labels=["risk:scope"],
+            start_date=date(2026, 4, 10),
+            target_date=date(2026, 4, 18),
+            created_at=datetime(2026, 4, 10, 12, 0, tzinfo=timezone.utc),
+            updated_at=datetime(2026, 4, 11, 8, 0, tzinfo=timezone.utc),
+            comments_count=4,
+            url="https://github.com/acme/proj/issues/101",
+            state="open",
+        ),
+        TaskItem(
+            id="102",
+            number=102,
+            title="Ship PM widget",
+            status=ItemStatus.DONE,
+            milestone_id=None,
+            milestone_title="",
+            priority=Priority.P3,
+            assignees=[],
+            effort=None,
+            labels=["p3"],
+            risk_labels=[],
+            start_date=None,
+            target_date=None,
+            created_at=datetime(2026, 4, 1, 9, 0, tzinfo=timezone.utc),
+            updated_at=datetime(2026, 4, 12, 10, 0, tzinfo=timezone.utc),
+            comments_count=0,
+            url="https://github.com/acme/proj/issues/102",
+            state="closed",
+        ),
+    ]
+
+
+@pytest.fixture
+def sample_details() -> TaskDetailData:
+    """Deterministic detail payload for a single task."""
+    return TaskDetailData(
+        number=101,
+        body="## Heading\n\nBody text.",
+        comments_count=2,
+        linked_prs=[
+            {"number": 200, "url": "https://github.com/acme/proj/pull/200"}
+        ],
+        labels=["p1", "risk:scope"],
+        assignees=["alberto"],
+        url="https://github.com/acme/proj/issues/101",
+    )

--- a/tests/test_task_widgets.py
+++ b/tests/test_task_widgets.py
@@ -191,7 +191,11 @@ async def test_row_selection_swaps_content_switcher(
 
 
 class _DrillDownHarness(App[None]):
-    """App that mounts a TaskDetail pre-populated with a task."""
+    """App that mounts a TaskDetail pre-populated with a task.
+
+    Catches :class:`TaskDetail.DrillDownRequested` and pushes
+    :class:`TaskDetailScreen` — mirrors the wiring in ``ProjectStatePane``.
+    """
 
     def __init__(
         self, task: TaskItem, details: TaskDetailData
@@ -212,6 +216,13 @@ class _DrillDownHarness(App[None]):
             if "comment" in str(btn.label).lower():
                 btn.focus()
                 break
+
+    def on_task_detail_drill_down_requested(
+        self, event: TaskDetail.DrillDownRequested
+    ) -> None:
+        from toad.screens.task_detail_screen import TaskDetailScreen
+
+        self.push_screen(TaskDetailScreen(event.task, self._task_details))
 
 
 @pytest.mark.asyncio

--- a/tests/test_task_widgets.py
+++ b/tests/test_task_widgets.py
@@ -1,0 +1,247 @@
+"""Tests for the Tasks-widget stack.
+
+Covers three concerns:
+1. Provider parsing — ``TaskProvider.fetch_tasks`` against mocked ``_run_gh``.
+2. Filter predicates — ``filter_toolbar.filter_tasks`` status/milestone/priority.
+3. Interaction flows via Textual's ``App.run_test()`` pilot:
+   - arrow + enter swaps the ``ContentSwitcher`` to the detail view,
+   - enter on "View comments" pushes ``TaskDetailScreen``,
+   - escape pops the screen back to the list.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.containers import Horizontal
+from textual.widgets import Button, ContentSwitcher, DataTable
+
+from toad.widgets.filter_toolbar import filter_tasks
+from toad.widgets.github_views.task_provider import (
+    TaskDetailData,
+    TaskItem,
+    TaskProvider,
+)
+from toad.widgets.github_views.timeline_provider import ItemStatus, Priority
+from toad.widgets.task_detail import TaskDetail
+from toad.widgets.task_table import TaskTable
+
+# ---------------------------------------------------------------------------
+# Provider parsing
+# ---------------------------------------------------------------------------
+
+
+class TestTaskProviderParsing:
+    """``TaskProvider.fetch_tasks`` must join issues + project board data."""
+
+    @pytest.mark.asyncio
+    async def test_fetch_tasks_joins_issues_and_board(
+        self,
+        mock_issues_payload: str,
+        mock_project_payload: str,
+    ) -> None:
+        responses = [mock_issues_payload, mock_project_payload]
+
+        async def fake_run_gh(*_args: Any, **_kwargs: Any) -> str:
+            return responses.pop(0)
+
+        with patch(
+            "toad.widgets.github_views.task_provider._run_gh",
+            side_effect=fake_run_gh,
+        ):
+            provider = TaskProvider(repo="acme/proj", project_number=1)
+            tasks = await provider.fetch_tasks()
+
+        assert len(tasks) == 2
+        by_number = {t.number: t for t in tasks}
+
+        t101 = by_number[101]
+        assert t101.id == "101"
+        assert t101.title == "Wire Tasks tab"
+        assert t101.status == ItemStatus.IN_PROGRESS
+        assert t101.milestone_title == "M1 — UI"
+        assert t101.priority == Priority.P1
+        assert t101.assignees == ["alberto"]
+        assert t101.effort == "2"
+        assert t101.risk_labels == ["risk:scope"]
+        assert t101.comments_count == 4
+
+        t102 = by_number[102]
+        assert t102.status == ItemStatus.DONE  # closed -> DONE
+        assert t102.priority == Priority.P3
+        assert t102.milestone_id is None
+        assert t102.assignees == []
+
+    @pytest.mark.asyncio
+    async def test_fetch_task_details_parses_body_and_prs(
+        self, mock_issue_detail_payload: str
+    ) -> None:
+        with patch(
+            "toad.widgets.github_views.task_provider._run_gh",
+            new=AsyncMock(return_value=mock_issue_detail_payload),
+        ):
+            provider = TaskProvider(repo="acme/proj", project_number=1)
+            details = await provider.fetch_task_details(101)
+
+        assert details.number == 101
+        assert "markdown" in details.body
+        assert details.comments_count == 2
+        assert details.linked_prs[0]["number"] == 200
+        assert details.labels == ["p1", "risk:scope"]
+
+
+# ---------------------------------------------------------------------------
+# Filter predicates
+# ---------------------------------------------------------------------------
+
+
+class TestFilterPredicates:
+    """``filter_tasks`` narrows a task list by status/milestone/priority."""
+
+    def test_no_filters_returns_all(
+        self, sample_tasks: list[TaskItem]
+    ) -> None:
+        assert filter_tasks(sample_tasks) == sample_tasks
+
+    def test_filter_by_status(self, sample_tasks: list[TaskItem]) -> None:
+        result = filter_tasks(sample_tasks, status=ItemStatus.IN_PROGRESS)
+        assert [t.number for t in result] == [101]
+
+    def test_filter_by_milestone(
+        self, sample_tasks: list[TaskItem]
+    ) -> None:
+        result = filter_tasks(sample_tasks, milestone_id="1")
+        assert [t.number for t in result] == [101]
+
+    def test_filter_by_priority(
+        self, sample_tasks: list[TaskItem]
+    ) -> None:
+        result = filter_tasks(sample_tasks, priority=Priority.P3)
+        assert [t.number for t in result] == [102]
+
+    def test_combined_filters_intersect(
+        self, sample_tasks: list[TaskItem]
+    ) -> None:
+        result = filter_tasks(
+            sample_tasks,
+            status=ItemStatus.DONE,
+            priority=Priority.P3,
+        )
+        assert [t.number for t in result] == [102]
+
+    def test_combined_no_match(self, sample_tasks: list[TaskItem]) -> None:
+        result = filter_tasks(
+            sample_tasks,
+            status=ItemStatus.IN_PROGRESS,
+            priority=Priority.P3,
+        )
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# Interaction flows via App.run_test()
+# ---------------------------------------------------------------------------
+
+
+class _SelectionHarness(App[None]):
+    """App that wires TaskTable ↔ TaskDetail without the full pane."""
+
+    def __init__(self, tasks: list[TaskItem]) -> None:
+        super().__init__()
+        self._tasks = tasks
+        self._by_id = {t.id: t for t in tasks}
+
+    def compose(self) -> ComposeResult:
+        with Horizontal():
+            yield TaskTable(id="tbl")
+            yield TaskDetail(id="detail")
+
+    async def on_mount(self) -> None:
+        tbl = self.query_one(TaskTable)
+        tbl.set_tasks(self._tasks)
+        tbl.focus()
+
+    def on_data_table_row_selected(
+        self, event: DataTable.RowSelected
+    ) -> None:
+        key = event.row_key.value
+        if key is None:
+            return
+        task = self._by_id.get(str(key))
+        if task is not None:
+            self.query_one(TaskDetail).show_task(task)
+
+
+@pytest.mark.asyncio
+async def test_row_selection_swaps_content_switcher(
+    sample_tasks: list[TaskItem],
+) -> None:
+    """`pilot.press("down", "enter")` → ContentSwitcher shows detail view."""
+    app = _SelectionHarness(sample_tasks)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await pilot.press("down", "enter")
+        await pilot.pause()
+        detail = app.query_one(TaskDetail)
+        switcher = detail.query_one(ContentSwitcher)
+        assert switcher.current == "detail"
+
+
+class _DrillDownHarness(App[None]):
+    """App that mounts a TaskDetail pre-populated with a task."""
+
+    def __init__(
+        self, task: TaskItem, details: TaskDetailData
+    ) -> None:
+        super().__init__()
+        self._task = task
+        self._details = details
+
+    def compose(self) -> ComposeResult:
+        yield TaskDetail(id="detail")
+
+    async def on_mount(self) -> None:
+        detail = self.query_one(TaskDetail)
+        detail.show_task(self._task)
+        detail.show_details(self._details)
+        # Focus the "View comments" control so Enter triggers drill-down.
+        for btn in detail.query(Button):
+            if "comment" in str(btn.label).lower():
+                btn.focus()
+                break
+
+
+@pytest.mark.asyncio
+async def test_view_comments_pushes_task_detail_screen(
+    sample_tasks: list[TaskItem], sample_details: TaskDetailData
+) -> None:
+    """Enter on "View comments" pushes ``TaskDetailScreen``."""
+    from toad.screens.task_detail_screen import TaskDetailScreen
+
+    app = _DrillDownHarness(sample_tasks[0], sample_details)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await pilot.press("enter")
+        await pilot.pause()
+        assert isinstance(app.screen, TaskDetailScreen)
+
+
+@pytest.mark.asyncio
+async def test_escape_pops_task_detail_screen(
+    sample_tasks: list[TaskItem], sample_details: TaskDetailData
+) -> None:
+    """Escape from ``TaskDetailScreen`` pops back to the list screen."""
+    from toad.screens.task_detail_screen import TaskDetailScreen
+
+    app = _SelectionHarness(sample_tasks)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        app.push_screen(TaskDetailScreen(sample_tasks[0], sample_details))
+        await pilot.pause()
+        assert isinstance(app.screen, TaskDetailScreen)
+        await pilot.press("escape")
+        await pilot.pause()
+        assert not isinstance(app.screen, TaskDetailScreen)

--- a/tests/test_task_widgets.py
+++ b/tests/test_task_widgets.py
@@ -151,7 +151,7 @@ class _SelectionHarness(App[None]):
 
     def __init__(self, tasks: list[TaskItem]) -> None:
         super().__init__()
-        self._tasks = tasks
+        self._task_list = tasks
         self._by_id = {t.id: t for t in tasks}
 
     def compose(self) -> ComposeResult:
@@ -161,7 +161,7 @@ class _SelectionHarness(App[None]):
 
     async def on_mount(self) -> None:
         tbl = self.query_one(TaskTable)
-        tbl.set_tasks(self._tasks)
+        tbl.set_tasks(self._task_list)
         tbl.focus()
 
     def on_data_table_row_selected(
@@ -197,16 +197,16 @@ class _DrillDownHarness(App[None]):
         self, task: TaskItem, details: TaskDetailData
     ) -> None:
         super().__init__()
-        self._task = task
-        self._details = details
+        self._task_item = task
+        self._task_details = details
 
     def compose(self) -> ComposeResult:
         yield TaskDetail(id="detail")
 
     async def on_mount(self) -> None:
         detail = self.query_one(TaskDetail)
-        detail.show_task(self._task)
-        detail.show_details(self._details)
+        detail.show_task(self._task_item)
+        detail.show_details(self._task_details)
         # Focus the "View comments" control so Enter triggers drill-down.
         for btn in detail.query(Button):
             if "comment" in str(btn.label).lower():

--- a/tools/verify-tui.py
+++ b/tools/verify-tui.py
@@ -6,6 +6,7 @@ Usage:
     uv run python tools/verify-tui.py --verbose
     uv run python tools/verify-tui.py --widget gantt
     uv run python tools/verify-tui.py --widget github
+    uv run python tools/verify-tui.py --widget tasks
 
 Runs the app or individual widgets headless and reports layout,
 scroll behavior, and rendering issues. Exit code 0 = all checks pass.
@@ -14,6 +15,8 @@ scroll behavior, and rendering issues. Exit code 0 = all checks pass.
 from __future__ import annotations
 
 import argparse
+import asyncio
+import subprocess
 import sys
 from datetime import date
 
@@ -183,8 +186,8 @@ def verify_pane_no_default(verbose: bool = False) -> bool:
     from textual.app import App, ComposeResult
     from toad.widgets.project_state_pane import (
         ProjectStatePane,
-        SECTION_GITHUB,
-        SECTION_BUILDER,
+        SECTION_PLANNING,
+        SECTION_STATE,
     )
 
     errors: list[str] = []
@@ -204,16 +207,20 @@ def verify_pane_no_default(verbose: bool = False) -> bool:
 
         def _check(self) -> None:
             pane = self.query_one("#psp", ProjectStatePane)
-            github = pane.query_one(f"#{SECTION_GITHUB}")
-            builder = pane.query_one(f"#{SECTION_BUILDER}")
+            planning = pane.query_one(f"#{SECTION_PLANNING}")
+            state = pane.query_one(f"#{SECTION_STATE}")
 
-            results["github_visible"] = github.display
-            results["builder_visible"] = builder.display
+            results["planning_visible"] = planning.display
+            results["state_visible"] = state.display
 
-            if github.display:
-                errors.append("GitHub section visible on mount (should be hidden)")
-            if builder.display:
-                errors.append("Builder section visible on mount (should be hidden)")
+            if planning.display:
+                errors.append(
+                    "Planning section visible on mount (should be hidden)"
+                )
+            if state.display:
+                errors.append(
+                    "State section visible on mount (should be hidden)"
+                )
 
             self.exit()
 
@@ -222,6 +229,208 @@ def verify_pane_no_default(verbose: bool = False) -> bool:
     if verbose:
         for key, val in results.items():
             console.print(f"  {key}: {val}")
+
+    return len(errors) == 0, errors, results
+
+
+def verify_tasks(verbose: bool = False) -> bool:
+    """Verify Tasks widget stack: mount + down/enter/escape interaction."""
+    from datetime import datetime
+
+    from textual.app import App, ComposeResult
+    from textual.containers import Horizontal
+    from textual.widgets import ContentSwitcher, DataTable
+
+    from toad.widgets.github_views.task_provider import TaskDetailData, TaskItem
+    from toad.widgets.github_views.timeline_provider import ItemStatus, Priority
+    from toad.widgets.filter_toolbar import FilterToolbar, filter_tasks
+    from toad.widgets.task_detail import TaskDetail
+    from toad.widgets.task_table import TaskTable
+    from toad.screens.task_detail_screen import TaskDetailScreen
+
+    errors: list[str] = []
+    results: dict[str, object] = {}
+
+    tasks = [
+        TaskItem(
+            id="101",
+            number=101,
+            title="Wire Tasks tab",
+            status=ItemStatus.IN_PROGRESS,
+            milestone_id="1",
+            milestone_title="M1 — UI",
+            priority=Priority.P1,
+            assignees=["alberto"],
+            effort="2",
+            labels=["p1-must-ship"],
+            comments_count=4,
+            created_at=datetime(2026, 4, 10, 12, 0),
+            updated_at=datetime(2026, 4, 15, 9, 0),
+            url="https://github.com/acme/proj/issues/101",
+        ),
+        TaskItem(
+            id="102",
+            number=102,
+            title="Document widgets",
+            status=ItemStatus.DONE,
+            milestone_id=None,
+            milestone_title="",
+            priority=Priority.P3,
+            assignees=[],
+            effort=None,
+            labels=["p3"],
+            comments_count=0,
+            url="https://github.com/acme/proj/issues/102",
+        ),
+    ]
+    details = TaskDetailData(
+        number=101,
+        body="# body\n\nrendered markdown here.",
+        comments_count=2,
+        linked_prs=[{"number": 200, "title": "PR"}],
+        labels=["p1-must-ship"],
+        assignees=["alberto"],
+        url="https://github.com/acme/proj/issues/101",
+    )
+
+    # --- Test 1: Filter predicate still wired ---
+    filtered = filter_tasks(tasks, status=ItemStatus.IN_PROGRESS)
+    if [t.number for t in filtered] != [101]:
+        errors.append(
+            f"filter_tasks: expected [101], got {[t.number for t in filtered]}"
+        )
+
+    # --- Test 2: All three widgets mount + interaction flow ---
+    class TasksHarness(App[None]):
+        CSS = "Screen { overflow: hidden; }"
+
+        def compose(self) -> ComposeResult:
+            yield FilterToolbar(id="tb")
+            with Horizontal(id="body"):
+                yield TaskTable(id="tbl")
+                yield TaskDetail(id="detail")
+
+        async def on_mount(self) -> None:
+            tbl = self.query_one(TaskTable)
+            tbl.set_tasks(tasks)
+            tbl.focus()
+
+        def on_data_table_row_selected(
+            self, event: DataTable.RowSelected
+        ) -> None:
+            key = event.row_key.value
+            if key is None:
+                return
+            match = next((t for t in tasks if t.id == str(key)), None)
+            if match is not None:
+                self.query_one(TaskDetail).show_task(match)
+
+    async def _run_interaction() -> None:
+        app = TasksHarness()
+        async with app.run_test(size=(120, 30)) as pilot:
+            await pilot.pause()
+            # Confirm all three widgets mounted.
+            app.query_one(FilterToolbar)
+            tbl = app.query_one(TaskTable)
+            detail = app.query_one(TaskDetail)
+            switcher = detail.query_one(ContentSwitcher)
+
+            results["row_count"] = tbl.row_count
+            results["initial_switcher"] = switcher.current
+
+            if tbl.row_count != len(tasks):
+                errors.append(
+                    f"table row_count={tbl.row_count}, expected {len(tasks)}"
+                )
+            if switcher.current != "empty":
+                errors.append(
+                    f"initial switcher={switcher.current}, expected 'empty'"
+                )
+
+            await pilot.press("down", "enter")
+            await pilot.pause()
+            results["after_enter_switcher"] = switcher.current
+            if switcher.current != "detail":
+                errors.append(
+                    f"after enter switcher={switcher.current}, expected 'detail'"
+                )
+
+            # Escape on list screen should be a no-op (no screen pushed).
+            await pilot.press("escape")
+            await pilot.pause()
+            results["after_escape_screen"] = type(app.screen).__name__
+            if isinstance(app.screen, TaskDetailScreen):
+                errors.append(
+                    "escape unexpectedly left TaskDetailScreen active on list"
+                )
+
+            # Push + escape round-trip: confirms screen-stack pop works.
+            app.push_screen(TaskDetailScreen(tasks[0], details))
+            await pilot.pause()
+            if not isinstance(app.screen, TaskDetailScreen):
+                errors.append("push_screen(TaskDetailScreen) did not activate")
+            await pilot.press("escape")
+            await pilot.pause()
+            results["final_screen"] = type(app.screen).__name__
+            if isinstance(app.screen, TaskDetailScreen):
+                errors.append(
+                    "escape on TaskDetailScreen did not pop back to list"
+                )
+
+    asyncio.run(_run_interaction())
+
+    if verbose:
+        for key, val in results.items():
+            console.print(f"  {key}: {val}")
+
+    return len(errors) == 0, errors, results
+
+
+def verify_live_data_probe(verbose: bool = False) -> bool:
+    """Probe the real GitHub API through TaskProvider.
+
+    Skips gracefully if `gh` is not installed or not authenticated.
+    """
+    errors: list[str] = []
+    results: dict[str, object] = {}
+
+    # Probe `gh auth status` — skip if unauth'd or gh missing.
+    try:
+        proc = subprocess.run(
+            ["gh", "auth", "status"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except FileNotFoundError:
+        console.print("  [yellow]skipped: no gh auth[/yellow] (gh not installed)")
+        return True, [], {"status": "skipped-no-gh"}
+    except subprocess.TimeoutExpired:
+        console.print("  [yellow]skipped: no gh auth[/yellow] (timeout)")
+        return True, [], {"status": "skipped-timeout"}
+
+    if proc.returncode != 0:
+        console.print("  [yellow]skipped: no gh auth[/yellow]")
+        return True, [], {"status": "skipped-unauth"}
+
+    # Run the fetch.
+    from toad.widgets.github_views.task_provider import TaskProvider
+
+    async def _fetch() -> int:
+        provider = TaskProvider(
+            repo="DEGAorg/claude-code-config", project_number=8
+        )
+        tasks = await provider.fetch_tasks()
+        return len(tasks)
+
+    try:
+        count = asyncio.run(_fetch())
+        results["task_count"] = count
+        if verbose:
+            console.print(f"  fetched {count} tasks from live GitHub API")
+    except Exception as exc:  # noqa: BLE001 - probe surfaces any parser break
+        errors.append(f"live fetch failed: {exc.__class__.__name__}: {exc}")
 
     return len(errors) == 0, errors, results
 
@@ -237,6 +446,11 @@ def verify_imports(verbose: bool = False) -> bool:
         "toad.widgets.github_views.timeline_provider",
         "toad.widgets.github_views.github_timeline_provider",
         "toad.widgets.github_views.timeline_data",
+        "toad.widgets.github_views.task_provider",
+        "toad.widgets.task_table",
+        "toad.widgets.task_detail",
+        "toad.widgets.filter_toolbar",
+        "toad.screens.task_detail_screen",
     ]
     for mod in modules:
         try:
@@ -252,7 +466,7 @@ def main() -> None:
     parser.add_argument("--verbose", "-v", action="store_true")
     parser.add_argument(
         "--widget",
-        choices=["gantt", "imports", "pane", "all"],
+        choices=["gantt", "imports", "pane", "tasks", "live", "all"],
         default="all",
     )
     args = parser.parse_args()
@@ -261,8 +475,12 @@ def main() -> None:
         "imports": verify_imports,
         "gantt": verify_gantt,
         "pane": verify_pane_no_default,
+        "tasks": verify_tasks,
     }
-    if args.widget != "all":
+    # Live probe only runs when explicitly requested — it hits the network.
+    if args.widget == "live":
+        checks = {"live": verify_live_data_probe}
+    elif args.widget != "all":
         checks = {args.widget: checks[args.widget]}
 
     all_passed = True


### PR DESCRIPTION
## Summary

Adds an interactive Tasks tab to `ProjectStatePane` (closes #22). Master-detail DataTable of GitHub project-board issues with markdown-rendered detail panel, filter toolbar (status / milestone / priority / title search), auto-refresh, and full-screen drill-down.

## What's in the diff

- **Data layer** — `TaskProvider.fetch_tasks()` + `fetch_task_details()` reuse `_run_gh()`; `TaskItem` / `TaskDetailData` dataclasses.
- **Widgets** — `TaskTable` (DataTable, row_key=issue id), `TaskDetail` (ContentSwitcher + Markdown body + Collapsible metadata), `FilterToolbar` (Select dropdowns + title Input + Refresh).
- **Integration** — new `TabPane("Tasks")` inside the Planning section; provider fetch → filter → table → detail; message-driven drill-down to `TaskDetailScreen` with Escape-to-pop and live detail updates.
- **Keybindings** — `r` refreshes, `/` focuses the title filter (active only while the Tasks tab is visible).
- **Status feedback** — inline label above the table shows loading, errors, empty-filter state, and Showing-N-of-M counts.
- **Tests** — 11 unit + pilot interaction tests covering provider parsing, filter predicates, row selection → detail swap, drill-down push, and Escape pop.
- **Verification** — `tools/verify-tui.py --widget tasks` exercises the full pilot flow; `--widget live` pulls 100 real tasks from the live project board.

## Deferred to phase 2

Critique comment on #22 lists 6 P2 findings (focus hotkeys, hardcoded title truncation, collapsed-by-default metadata, last-refresh timestamp, metadata reflow). Not addressed here.

## Test plan

- [x] `uv run pytest -q tests/test_task_widgets.py` — 11 passed
- [x] `uv run python tools/verify-tui.py --widget tasks` — PASS
- [x] `uv run python tools/verify-tui.py --widget live` — PASS (100 tasks fetched)
- [x] `uv run python tools/verify-tui.py --verbose` — no regressions on gantt/github
- [x] `uv run ruff check` on new files — clean
- [x] `uv run canon .` boots without tracebacks
- [ ] Human smoke: open Tasks tab, select a row, press Enter on "View comments", press Escape

🤖 Generated with [Claude Code](https://claude.com/claude-code)