### PR TITLE
Plan execution bootstrap: PlanExecutionModel + auto-open tab (closes #37)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ### Changed
+- Canon TUI — bootstrap PlanExecutionModel + auto-open plan tab (`20260427-plan-execution-bootstrap`) — 2026-04-27
 
 - Canon TUI view — PlanExecutionTab + dedicated section (`20260422-plan-execution-tab`) — 2026-04-23
 

--- a/src/toad/data/__init__.py
+++ b/src/toad/data/__init__.py
@@ -1,0 +1,13 @@
+"""Data layer for the Canon TUI.
+
+Currently re-exports :class:`PlanExecutionModel`, the watcher that turns
+an orchestrator plan directory (``.orchestrator/plans/<slug>/``) into
+the Textual messages the plan-execution widgets already handle.
+"""
+
+from __future__ import annotations
+
+from toad.data.plan_execution_model import PlanExecutionModel
+
+
+__all__ = ["PlanExecutionModel"]

--- a/src/toad/data/plan_execution_model.py
+++ b/src/toad/data/plan_execution_model.py
@@ -1,0 +1,243 @@
+"""PlanExecutionModel — watch an orchestrator plan directory.
+
+Reads ``.orchestrator/plans/<slug>/state.json`` plus per-item
+``logs/<id>.log`` files and posts the Textual messages the existing
+plan-execution widgets already handle:
+
+- :class:`toad.widgets.plan_execution_tab.PlanExecutionTab.ItemStatusChanged`
+  whenever an item's ``status`` field flips,
+- :class:`toad.widgets.plan_execution_tab.PlanExecutionTab.PlanFinished`
+  the first time ``finalReview.verdict`` reaches a terminal value
+  (``SHIP`` or ``REVISE``),
+- log chunks delivered through callbacks registered via
+  :meth:`subscribe_log` — the path the
+  :class:`toad.widgets.plan_worker_log_pane.PlanWorkerLogPane` already
+  drives to raise its ``ItemLogAppended`` message.
+
+The model owns no Textual widgets and does no rendering. Construction
+parses ``state.json`` once so callers can introspect ``slug``,
+``issue_number``, ``items``, and ``verdict`` synchronously. After
+:meth:`start`, every call to :meth:`poll_now` rescans the plan
+directory and posts whatever changed.
+
+Polling mode (the default, ``poll=True``) gives tests a deterministic,
+synchronous trigger and avoids spawning a watcher thread. Production
+callers should still use ``poll=True`` and drive :meth:`poll_now` from
+a Textual interval — file watching is intentionally out of scope here.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, Protocol
+
+from toad.widgets.plan_dep_graph import DepGraphItem
+from toad.widgets.plan_execution_tab import PlanExecutionTab
+
+
+__all__ = ["PlanExecutionModel"]
+
+
+_TERMINAL_VERDICTS = frozenset({"SHIP", "REVISE"})
+_DEFAULT_VERDICT = "running"
+
+
+class _MessageTarget(Protocol):
+    """Slice of ``textual.widget.Widget`` the model needs."""
+
+    def post_message(self, message: Any) -> bool: ...
+
+
+class PlanExecutionModel:
+    """Polls an orchestrator plan directory and posts widget messages."""
+
+    def __init__(
+        self,
+        plan_dir: Path,
+        *,
+        target: _MessageTarget,
+        poll: bool = True,
+    ) -> None:
+        self._plan_dir = Path(plan_dir)
+        self._target = target
+        self._poll_only = poll
+        self._lock = threading.Lock()
+
+        self._slug: str = ""
+        self._issue_number: int | None = None
+        self._items: list[DepGraphItem] = []
+        self._verdict: str = _DEFAULT_VERDICT
+        self._finished_emitted: bool = False
+        self._started: bool = False
+
+        self._log_positions: dict[int, int] = {}
+        self._log_subscribers: dict[int, list[Callable[[str], None]]] = {}
+
+        self._initial_parse()
+
+    # ------------------------------------------------------------------
+    # Public attributes
+    # ------------------------------------------------------------------
+
+    @property
+    def slug(self) -> str:
+        return self._slug
+
+    @property
+    def issue_number(self) -> int | None:
+        return self._issue_number
+
+    @property
+    def items(self) -> list[DepGraphItem]:
+        """Snapshot of plan items in the order ``state.json`` lists them."""
+        return list(self._items)
+
+    @property
+    def verdict(self) -> str:
+        return self._verdict
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def start(self) -> None:
+        """Mark the model as live; subsequent ``poll_now`` calls emit diffs."""
+        self._started = True
+
+    def stop(self) -> None:
+        """Stop emitting diffs. Idempotent."""
+        self._started = False
+
+    def poll_now(self) -> None:
+        """Synchronous rescan — read ``state.json`` and tail subscribed logs."""
+        self._scan_state()
+        self._scan_logs()
+
+    # ------------------------------------------------------------------
+    # Subscriptions
+    # ------------------------------------------------------------------
+
+    def subscribe_log(
+        self, item_id: int, callback: Callable[[str], None]
+    ) -> Callable[[], None]:
+        """Subscribe ``callback`` to item ``item_id``'s log stream.
+
+        The returned callable removes the subscription. After the last
+        subscriber for an item unsubscribes, the model stops tailing
+        that item's log file until a new subscription arrives.
+        """
+        with self._lock:
+            self._log_subscribers.setdefault(item_id, []).append(callback)
+
+        def _unsubscribe() -> None:
+            with self._lock:
+                subs = self._log_subscribers.get(item_id)
+                if subs is None:
+                    return
+                try:
+                    subs.remove(callback)
+                except ValueError:
+                    pass
+                if not subs:
+                    self._log_subscribers.pop(item_id, None)
+
+        return _unsubscribe
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _initial_parse(self) -> None:
+        payload = self._read_state()
+        if payload is None:
+            return
+        self._slug = str(payload.get("plan", ""))
+        issue = payload.get("issueNumber")
+        self._issue_number = int(issue) if isinstance(issue, int) else None
+        self._items = [self._item_from_dict(it) for it in payload.get("items", [])]
+        verdict = self._extract_verdict(payload)
+        self._verdict = verdict
+        if verdict in _TERMINAL_VERDICTS:
+            # Treat plans that are already terminal at construction as
+            # having been announced — we don't replay history.
+            self._finished_emitted = True
+
+    def _scan_state(self) -> None:
+        payload = self._read_state()
+        if payload is None:
+            return
+        new_items = [self._item_from_dict(it) for it in payload.get("items", [])]
+        old_status: dict[int, str] = {it.id: it.status for it in self._items}
+        for item in new_items:
+            prev = old_status.get(item.id)
+            if prev is not None and prev != item.status:
+                self._target.post_message(
+                    PlanExecutionTab.ItemStatusChanged(item.id, item.status)
+                )
+        self._items = new_items
+
+        verdict = self._extract_verdict(payload)
+        self._verdict = verdict
+        if verdict in _TERMINAL_VERDICTS and not self._finished_emitted:
+            self._finished_emitted = True
+            self._target.post_message(PlanExecutionTab.PlanFinished(verdict))
+
+    def _scan_logs(self) -> None:
+        with self._lock:
+            ids = list(self._log_subscribers.keys())
+        for item_id in ids:
+            log_path = self._plan_dir / "logs" / f"{item_id}.log"
+            if not log_path.exists():
+                continue
+            pos = self._log_positions.get(item_id, 0)
+            try:
+                size = log_path.stat().st_size
+            except OSError:
+                continue
+            if size <= pos:
+                continue
+            try:
+                with log_path.open("r", encoding="utf-8") as fh:
+                    fh.seek(pos)
+                    chunk = fh.read()
+                    new_pos = fh.tell()
+            except OSError:
+                continue
+            self._log_positions[item_id] = new_pos
+            if not chunk:
+                continue
+            with self._lock:
+                callbacks = list(self._log_subscribers.get(item_id, ()))
+            for cb in callbacks:
+                cb(chunk)
+
+    def _read_state(self) -> dict[str, Any] | None:
+        path = self._plan_dir / "state.json"
+        if not path.exists():
+            return None
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return None
+        return data if isinstance(data, dict) else None
+
+    @staticmethod
+    def _extract_verdict(payload: dict[str, Any]) -> str:
+        review = payload.get("finalReview")
+        if isinstance(review, dict):
+            value = review.get("verdict")
+            if isinstance(value, str) and value:
+                return value
+        return _DEFAULT_VERDICT
+
+    @staticmethod
+    def _item_from_dict(data: dict[str, Any]) -> DepGraphItem:
+        return DepGraphItem(
+            id=int(data["id"]),
+            description=str(data.get("description", "")),
+            status=str(data.get("status", "queued")),
+            deps=tuple(int(d) for d in data.get("deps", [])),
+        )

--- a/src/toad/screens/main.py
+++ b/src/toad/screens/main.py
@@ -1,7 +1,13 @@
+from collections.abc import Callable
 from functools import partial
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 import random
+
+if TYPE_CHECKING:
+    from toad.widgets.plan_execution_tab import (
+        PlanExecutionModel as PlanExecutionModelProtocol,
+    )
 
 from textual import on
 from textual.app import ComposeResult
@@ -241,6 +247,33 @@ class MainScreen(Screen, can_focus=False):
             tree.data_bind(path=MainScreen.project_path)
         for tree in self.query(DirectoryTree):
             tree.guide_depth = 3
+
+        pane = self.query_one("#project_state_pane", ProjectStatePane)
+        pane.configure_plan_execution(self._make_plan_execution_factory(pane))
+
+    def _make_plan_execution_factory(
+        self, target: ProjectStatePane
+    ) -> Callable[[str], "PlanExecutionModelProtocol | None"]:
+        """Build the factory passed to ``ProjectStatePane.configure_plan_execution``.
+
+        The factory resolves ``.orchestrator/plans/<slug>/`` under the
+        current project path and constructs a live
+        :class:`PlanExecutionModel` rooted at it. Messages from the
+        model bubble up through the section to the active tab.
+        """
+        from typing import cast
+
+        from toad.data.plan_execution_model import PlanExecutionModel
+
+        def factory(slug: str) -> "PlanExecutionModelProtocol | None":
+            plan_dir = self.project_path / ".orchestrator" / "plans" / slug
+            if not plan_dir.is_dir():
+                return None
+            model = PlanExecutionModel(plan_dir, target=target)
+            model.start()
+            return cast("PlanExecutionModelProtocol", model)
+
+        return factory
 
     @on(OptionList.OptionHighlighted)
     def on_option_list_option_highlighted(

--- a/src/toad/widgets/plan_execution_section.py
+++ b/src/toad/widgets/plan_execution_section.py
@@ -21,15 +21,24 @@ from typing import Any
 
 from textual.app import ComposeResult
 from textual.containers import Vertical
-from textual.widgets import TabbedContent
+from textual.widgets import Static, TabbedContent, TabPane
 
 from toad.widgets.plan_execution_tab import PlanExecutionModel, PlanExecutionTab
 
 
 __all__ = [
+    "EMPTY_PANE_ID",
     "ModelFactory",
     "PlanExecutionSection",
 ]
+
+
+EMPTY_PANE_ID = "plan-exec-empty"
+_EMPTY_PANE_TITLE = "Plans"
+_EMPTY_PLACEHOLDER_TEXT = (
+    "No plan execution running.\n\n"
+    "Start one with:  bash ~/.claude/scripts/orch-run.sh <slug>"
+)
 
 
 log = logging.getLogger(__name__)
@@ -57,6 +66,11 @@ class PlanExecutionSection(Vertical):
     PlanExecutionSection TabbedContent {
         height: 1fr;
     }
+
+    PlanExecutionSection .empty-state {
+        padding: 2 4;
+        color: $text-muted;
+    }
     """
 
     def __init__(
@@ -78,7 +92,16 @@ class PlanExecutionSection(Vertical):
     # ------------------------------------------------------------------
 
     def compose(self) -> ComposeResult:
-        yield TabbedContent(id="plan-exec-tabs")
+        with TabbedContent(id="plan-exec-tabs"):
+            yield self._build_empty_pane()
+
+    @staticmethod
+    def _build_empty_pane() -> TabPane:
+        return TabPane(
+            _EMPTY_PANE_TITLE,
+            Static(_EMPTY_PLACEHOLDER_TEXT, classes="empty-state"),
+            id=EMPTY_PANE_ID,
+        )
 
     # ------------------------------------------------------------------
     # Public API
@@ -121,6 +144,8 @@ class PlanExecutionSection(Vertical):
             id=tab_id,
         )
         tabs = self.query_one("#plan-exec-tabs", TabbedContent)
+        if not self._open_slugs:
+            self._remove_empty_pane(tabs)
         tabs.add_pane(tab)
         self._open_slugs.add(slug)
         self.display = True
@@ -128,14 +153,19 @@ class PlanExecutionSection(Vertical):
         return tab_id
 
     def close_tab(self, slug: str) -> None:
-        """Close a plan tab. No-op if ``slug`` is unknown."""
+        """Close a plan tab. No-op if ``slug`` is unknown.
+
+        ``master.json`` dropping a slug is *not* a close trigger — finished
+        runs keep their tab mounted. The user (or test) calls this method
+        explicitly.
+        """
         if slug not in self._open_slugs:
             return
         self._open_slugs.remove(slug)
         tabs = self.query_one("#plan-exec-tabs", TabbedContent)
         tabs.remove_pane(self._tab_id(slug))
         if not self._open_slugs:
-            self.display = False
+            tabs.add_pane(self._build_empty_pane())
 
     # ------------------------------------------------------------------
     # Internals
@@ -144,6 +174,14 @@ class PlanExecutionSection(Vertical):
     def _activate(self, tab_id: str) -> None:
         tabs = self.query_one("#plan-exec-tabs", TabbedContent)
         tabs.active = tab_id
+
+    @staticmethod
+    def _remove_empty_pane(tabs: TabbedContent) -> None:
+        try:
+            tabs.query_one(f"#{EMPTY_PANE_ID}", TabPane)
+        except Exception:
+            return
+        tabs.remove_pane(EMPTY_PANE_ID)
 
     @staticmethod
     def _tab_id(slug: str) -> str:

--- a/src/toad/widgets/project_state_pane.py
+++ b/src/toad/widgets/project_state_pane.py
@@ -575,14 +575,53 @@ class ProjectStatePane(Vertical):
         """Register the Phase B model factory + agent getter.
 
         Called by Canon's ACP bootstrap when the ``PlanExecutionModel``
-        factory is ready. Mounts the section lazily and pushes the
-        factory into it so subsequent ``PlansUpdated`` messages can
-        open tabs.
+        factory is ready. Mounts the section lazily, pushes the
+        factory into it, registers the ``Plans`` toolbar button, and
+        replays any plans already known to the orchestrator watcher
+        so tabs appear even if ``PlansUpdated`` fired before this call.
         """
         self._plan_model_factory = model_factory
         self._plan_agent_getter = get_current_agent
         section = self._ensure_plan_exec_section()
         section.set_model_factory(model_factory)
+        self._register_plan_exec_section()
+        self._replay_pending_plans(section)
+
+    def _register_plan_exec_section(self) -> None:
+        """Append the plan-exec section to ``_sections`` and mount its button."""
+        sec_id = PlanExecutionSection.SECTION_ID
+        if any(s.section_id == sec_id for s in self._sections):
+            return
+        sec_def = _SectionDef(sec_id, "Plans")
+        self._sections.append(sec_def)
+        try:
+            toolbar = self.query_one("#pane-toolbar", Horizontal)
+        except NoMatches:
+            return
+        btn = Button(sec_def.button_label, id=f"btn-{sec_id}")
+        try:
+            stack_btn = toolbar.query_one("#btn-stack-toggle", Button)
+            toolbar.mount(btn, before=stack_btn)
+        except NoMatches:
+            toolbar.mount(btn)
+        self._sync_toolbar()
+
+    def _replay_pending_plans(self, section: PlanExecutionSection) -> None:
+        """Open tabs for any plans already known to the orchestrator widget."""
+        try:
+            widget = self.query_one(
+                "#orchestrator-state", OrchestratorStateWidget
+            )
+        except NoMatches:
+            return
+        plans = list(widget.plans)
+        if not plans:
+            return
+        self.display = True
+        self.show_section(PlanExecutionSection.SECTION_ID)
+        for plan in plans:
+            if plan.slug:
+                section.open_tab(plan.slug)
 
     def _ensure_plan_exec_section(self) -> PlanExecutionSection:
         if self._plan_exec_section is None:
@@ -609,6 +648,8 @@ class ProjectStatePane(Vertical):
         if not event.plans:
             return
         section = self._ensure_plan_exec_section()
+        self.display = True
+        self.show_section(PlanExecutionSection.SECTION_ID)
         for plan in event.plans:
             if plan.slug:
                 section.open_tab(plan.slug)

--- a/tests/data/test_plan_execution_model.py
+++ b/tests/data/test_plan_execution_model.py
@@ -1,0 +1,347 @@
+"""Pilot tests for ``toad.data.plan_execution_model.PlanExecutionModel``.
+
+The model watches an orchestrator plan directory
+(``.orchestrator/plans/<slug>/``) for changes to ``state.json`` and
+per-item ``logs/<id>.log`` files, then posts Textual messages that the
+existing plan-execution widgets handle:
+
+- ``PlanExecutionTab.ItemStatusChanged`` when an item's ``status`` flips
+- ``PlanWorkerLogPane.ItemLogAppended`` (delivered through the
+  ``subscribe_log`` callback) when a log file grows
+- ``PlanExecutionTab.PlanFinished`` when the plan reaches a terminal
+  verdict
+
+These pilot tests pin the public surface of the model. They use polling
+mode (no real filesystem watcher thread) and a synchronous ``poll_now``
+hook so behaviour is deterministic across platforms.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from toad.data.plan_execution_model import PlanExecutionModel
+from toad.widgets.plan_execution_tab import PlanExecutionTab
+from toad.widgets.plan_worker_log_pane import PlanWorkerLogPane
+
+
+# ----------------------------------------------------------------------
+# Test doubles
+# ----------------------------------------------------------------------
+
+
+@dataclass
+class _Recorder:
+    """Captures messages the model would post to a Textual widget."""
+
+    messages: list[Any] = field(default_factory=list)
+
+    def post_message(self, message: Any) -> bool:
+        self.messages.append(message)
+        return True
+
+
+def _state_payload(
+    *,
+    items: Iterable[dict[str, Any]],
+    verdict: str | None = None,
+    issue_number: int | None = 42,
+    slug: str = "20260427-test-plan",
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "version": 1,
+        "plan": slug,
+        "issueNumber": issue_number,
+        "items": list(items),
+    }
+    if verdict is not None:
+        payload["finalReview"] = {"verdict": verdict}
+    return payload
+
+
+def _write_state(plan_dir: Path, payload: dict[str, Any]) -> None:
+    (plan_dir / "state.json").write_text(json.dumps(payload), encoding="utf-8")
+
+
+# ----------------------------------------------------------------------
+# Fixtures
+# ----------------------------------------------------------------------
+
+
+@pytest.fixture
+def plan_dir(tmp_path: Path) -> Path:
+    """Create an orchestrator plan dir with a minimal ``state.json``."""
+    pdir = tmp_path / ".orchestrator" / "plans" / "20260427-test-plan"
+    (pdir / "logs").mkdir(parents=True)
+    _write_state(
+        pdir,
+        _state_payload(
+            items=[
+                {
+                    "id": 1,
+                    "description": "alpha",
+                    "deps": [],
+                    "status": "running",
+                },
+                {
+                    "id": 2,
+                    "description": "beta",
+                    "deps": [1],
+                    "status": "queued",
+                },
+            ],
+        ),
+    )
+    return pdir
+
+
+# ----------------------------------------------------------------------
+# Initial parse
+# ----------------------------------------------------------------------
+
+
+class TestInitialParse:
+    """The model parses ``state.json`` on construction."""
+
+    def test_exposes_slug_issue_items_and_verdict(self, plan_dir: Path) -> None:
+        target = _Recorder()
+        model = PlanExecutionModel(plan_dir, target=target, poll=True)
+
+        assert model.slug == "20260427-test-plan"
+        assert model.issue_number == 42
+        assert [item.id for item in model.items] == [1, 2]
+        assert [item.status for item in model.items] == ["running", "queued"]
+        assert model.items[1].deps == (1,)
+        assert model.verdict == "running"
+
+    def test_no_messages_posted_on_construction(self, plan_dir: Path) -> None:
+        """Initial parse populates state but emits nothing."""
+        target = _Recorder()
+        PlanExecutionModel(plan_dir, target=target, poll=True)
+        assert target.messages == []
+
+
+# ----------------------------------------------------------------------
+# ItemStatusChanged
+# ----------------------------------------------------------------------
+
+
+class TestItemStatusChanged:
+    """Status flips in ``state.json`` produce ``ItemStatusChanged``."""
+
+    def test_emits_when_item_status_flips(self, plan_dir: Path) -> None:
+        target = _Recorder()
+        model = PlanExecutionModel(plan_dir, target=target, poll=True)
+        model.start()
+        try:
+            _write_state(
+                plan_dir,
+                _state_payload(
+                    items=[
+                        {
+                            "id": 1,
+                            "description": "alpha",
+                            "deps": [],
+                            "status": "done",
+                        },
+                        {
+                            "id": 2,
+                            "description": "beta",
+                            "deps": [1],
+                            "status": "running",
+                        },
+                    ],
+                ),
+            )
+            model.poll_now()
+        finally:
+            model.stop()
+
+        flips = [
+            (m.item_id, m.status)
+            for m in target.messages
+            if isinstance(m, PlanExecutionTab.ItemStatusChanged)
+        ]
+        assert (1, "done") in flips
+        assert (2, "running") in flips
+
+    def test_no_message_when_status_unchanged(self, plan_dir: Path) -> None:
+        target = _Recorder()
+        model = PlanExecutionModel(plan_dir, target=target, poll=True)
+        model.start()
+        try:
+            # Re-write the same payload — nothing changed.
+            _write_state(
+                plan_dir,
+                _state_payload(
+                    items=[
+                        {
+                            "id": 1,
+                            "description": "alpha",
+                            "deps": [],
+                            "status": "running",
+                        },
+                        {
+                            "id": 2,
+                            "description": "beta",
+                            "deps": [1],
+                            "status": "queued",
+                        },
+                    ],
+                ),
+            )
+            model.poll_now()
+        finally:
+            model.stop()
+
+        flips = [
+            m
+            for m in target.messages
+            if isinstance(m, PlanExecutionTab.ItemStatusChanged)
+        ]
+        assert flips == []
+
+
+# ----------------------------------------------------------------------
+# ItemLogAppended
+# ----------------------------------------------------------------------
+
+
+class TestItemLogAppended:
+    """New lines in ``logs/<id>.log`` reach ``subscribe_log`` callbacks."""
+
+    def test_subscriber_receives_appended_text(self, plan_dir: Path) -> None:
+        target = _Recorder()
+        model = PlanExecutionModel(plan_dir, target=target, poll=True)
+        received: list[str] = []
+        unsubscribe = model.subscribe_log(1, received.append)
+        model.start()
+        try:
+            log_path = plan_dir / "logs" / "1.log"
+            log_path.write_text("first line\n", encoding="utf-8")
+            model.poll_now()
+            with log_path.open("a", encoding="utf-8") as fh:
+                fh.write("second line\n")
+            model.poll_now()
+        finally:
+            unsubscribe()
+            model.stop()
+
+        joined = "".join(received)
+        assert "first line" in joined
+        assert "second line" in joined
+
+    def test_unsubscribe_stops_delivery(self, plan_dir: Path) -> None:
+        target = _Recorder()
+        model = PlanExecutionModel(plan_dir, target=target, poll=True)
+        received: list[str] = []
+        unsubscribe = model.subscribe_log(1, received.append)
+        model.start()
+        try:
+            log_path = plan_dir / "logs" / "1.log"
+            log_path.write_text("before unsub\n", encoding="utf-8")
+            model.poll_now()
+            unsubscribe()
+            with log_path.open("a", encoding="utf-8") as fh:
+                fh.write("after unsub\n")
+            model.poll_now()
+        finally:
+            model.stop()
+
+        joined = "".join(received)
+        assert "before unsub" in joined
+        assert "after unsub" not in joined
+
+    def test_log_pane_message_class_is_used(self, plan_dir: Path) -> None:
+        """The log-append message class lives on ``PlanWorkerLogPane``.
+
+        This is a regression pin — if the class is renamed or moved, the
+        worker-log pane and the model both break together, so make the
+        symbol's home explicit.
+        """
+        assert hasattr(PlanWorkerLogPane, "ItemLogAppended")
+
+
+# ----------------------------------------------------------------------
+# PlanFinished
+# ----------------------------------------------------------------------
+
+
+class TestPlanFinished:
+    """A terminal verdict in ``state.json`` produces ``PlanFinished``."""
+
+    def test_emits_when_verdict_set(self, plan_dir: Path) -> None:
+        target = _Recorder()
+        model = PlanExecutionModel(plan_dir, target=target, poll=True)
+        model.start()
+        try:
+            _write_state(
+                plan_dir,
+                _state_payload(
+                    items=[
+                        {
+                            "id": 1,
+                            "description": "alpha",
+                            "deps": [],
+                            "status": "done",
+                        },
+                        {
+                            "id": 2,
+                            "description": "beta",
+                            "deps": [1],
+                            "status": "done",
+                        },
+                    ],
+                    verdict="SHIP",
+                ),
+            )
+            model.poll_now()
+        finally:
+            model.stop()
+
+        finished = [
+            m for m in target.messages if isinstance(m, PlanExecutionTab.PlanFinished)
+        ]
+        assert len(finished) == 1
+        assert finished[0].verdict == "SHIP"
+        assert model.verdict == "SHIP"
+
+    def test_emits_at_most_once_per_terminal_verdict(self, plan_dir: Path) -> None:
+        target = _Recorder()
+        model = PlanExecutionModel(plan_dir, target=target, poll=True)
+        model.start()
+        try:
+            payload = _state_payload(
+                items=[
+                    {
+                        "id": 1,
+                        "description": "alpha",
+                        "deps": [],
+                        "status": "done",
+                    },
+                    {
+                        "id": 2,
+                        "description": "beta",
+                        "deps": [1],
+                        "status": "done",
+                    },
+                ],
+                verdict="SHIP",
+            )
+            _write_state(plan_dir, payload)
+            model.poll_now()
+            # A second poll without any state change must not re-emit.
+            model.poll_now()
+        finally:
+            model.stop()
+
+        finished = [
+            m for m in target.messages if isinstance(m, PlanExecutionTab.PlanFinished)
+        ]
+        assert len(finished) == 1

--- a/tests/widgets/test_plan_execution_section.py
+++ b/tests/widgets/test_plan_execution_section.py
@@ -1,0 +1,197 @@
+"""Tests for ``PlanExecutionSection``.
+
+Two contracts are exercised:
+
+- **Empty state.** When no plan tabs are open the section renders a
+  single placeholder ``TabPane`` containing a ``Static`` with the
+  ``empty-state`` class. Opening the first real tab removes the
+  placeholder; closing the last real tab restores it.
+- **Persistent finished tabs.** ``PlanExecutionSection`` has no hook
+  that automatically removes a tab when its slug drops out of
+  ``master.json`` — finished tabs stay mounted until the user closes
+  them explicitly via :meth:`close_tab`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.widgets import Static, TabbedContent, TabPane
+
+from toad.widgets.plan_execution_section import (
+    EMPTY_PANE_ID,
+    PlanExecutionSection,
+)
+from toad.widgets.plan_execution_tab import PlanExecutionTab
+
+
+# ----------------------------------------------------------------------
+# Test doubles
+# ----------------------------------------------------------------------
+
+
+@dataclass
+class _StubModel:
+    slug: str
+    issue_number: int | None = 7
+    items: list[Any] = field(default_factory=list)
+    verdict: str = "running"
+
+    def subscribe_log(
+        self, item_id: int, callback: Callable[[str], None]
+    ) -> Callable[[], None]:
+        del item_id, callback
+        return lambda: None
+
+
+def _factory(slug: str) -> _StubModel:
+    return _StubModel(slug=slug)
+
+
+class _Harness(App[None]):
+    def __init__(self, *, with_factory: bool = True) -> None:
+        super().__init__()
+        self._with_factory = with_factory
+
+    def compose(self) -> ComposeResult:
+        yield PlanExecutionSection(
+            model_factory=_factory if self._with_factory else None,
+            id=PlanExecutionSection.SECTION_ID,
+        )
+
+
+def _empty_state_statics(section: PlanExecutionSection) -> list[Static]:
+    return [
+        node
+        for node in section.query(Static)
+        if "empty-state" in node.classes
+    ]
+
+
+# ----------------------------------------------------------------------
+# Empty state
+# ----------------------------------------------------------------------
+
+
+class TestEmptyState:
+    @pytest.mark.asyncio
+    async def test_placeholder_pane_present_when_no_tabs(self) -> None:
+        app = _Harness()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            section = app.query_one(PlanExecutionSection)
+            tabs = section.query_one("#plan-exec-tabs", TabbedContent)
+            pane_ids = {pane.id for pane in tabs.query(TabPane)}
+            assert EMPTY_PANE_ID in pane_ids
+            assert _empty_state_statics(section), (
+                "section must render a Static.empty-state when idle"
+            )
+
+    @pytest.mark.asyncio
+    async def test_placeholder_removed_after_first_tab_opens(self) -> None:
+        app = _Harness()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            section = app.query_one(PlanExecutionSection)
+            section.open_tab("alpha")
+            await pilot.pause()
+            await pilot.pause()
+            tabs = section.query_one("#plan-exec-tabs", TabbedContent)
+            pane_ids = {pane.id for pane in tabs.query(TabPane)}
+            assert EMPTY_PANE_ID not in pane_ids
+            assert "plan-tab-alpha" in pane_ids
+
+    @pytest.mark.asyncio
+    async def test_placeholder_restored_after_last_tab_closes(self) -> None:
+        app = _Harness()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            section = app.query_one(PlanExecutionSection)
+            section.open_tab("alpha")
+            await pilot.pause()
+            await pilot.pause()
+            section.close_tab("alpha")
+            await pilot.pause()
+            await pilot.pause()
+            tabs = section.query_one("#plan-exec-tabs", TabbedContent)
+            pane_ids = {pane.id for pane in tabs.query(TabPane)}
+            assert EMPTY_PANE_ID in pane_ids
+            assert _empty_state_statics(section)
+
+    @pytest.mark.asyncio
+    async def test_placeholder_present_without_factory(self) -> None:
+        app = _Harness(with_factory=False)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            section = app.query_one(PlanExecutionSection)
+            assert _empty_state_statics(section)
+
+
+# ----------------------------------------------------------------------
+# Persistent finished tabs
+# ----------------------------------------------------------------------
+
+
+class TestPersistentTabs:
+    @pytest.mark.asyncio
+    async def test_open_tab_persists_without_explicit_close(self) -> None:
+        app = _Harness()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            section = app.query_one(PlanExecutionSection)
+            section.open_tab("alpha")
+            await pilot.pause()
+            await pilot.pause()
+            # Nothing else touches the section. Pump the event loop a few
+            # times — there's no auto-close mechanism that should fire.
+            for _ in range(3):
+                await pilot.pause()
+            assert "alpha" in section.open_slugs
+            tab = section.query_one("#plan-tab-alpha", PlanExecutionTab)
+            assert tab is not None
+
+    @pytest.mark.asyncio
+    async def test_finished_tab_kept_when_other_tabs_open(self) -> None:
+        """Two tabs open; closing one keeps the other mounted."""
+        app = _Harness()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            section = app.query_one(PlanExecutionSection)
+            section.open_tab("alpha")
+            await pilot.pause()
+            section.open_tab("beta")
+            await pilot.pause()
+            await pilot.pause()
+            section.close_tab("alpha")
+            await pilot.pause()
+            await pilot.pause()
+            assert "alpha" not in section.open_slugs
+            assert "beta" in section.open_slugs
+            # Empty placeholder must NOT be present while one tab remains.
+            tabs = section.query_one("#plan-exec-tabs", TabbedContent)
+            pane_ids = {pane.id for pane in tabs.query(TabPane)}
+            assert EMPTY_PANE_ID not in pane_ids
+            assert "plan-tab-beta" in pane_ids
+
+    @pytest.mark.asyncio
+    async def test_open_tab_idempotent_on_repeated_slug(self) -> None:
+        app = _Harness()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            section = app.query_one(PlanExecutionSection)
+            first = section.open_tab("alpha")
+            await pilot.pause()
+            second = section.open_tab("alpha")
+            await pilot.pause()
+            assert first == second == "plan-tab-alpha"
+            tabs = section.query_one("#plan-exec-tabs", TabbedContent)
+            slug_panes = [
+                pane
+                for pane in tabs.query(TabPane)
+                if pane.id == "plan-tab-alpha"
+            ]
+            assert len(slug_panes) == 1

--- a/tests/widgets/test_project_state_pane_orch.py
+++ b/tests/widgets/test_project_state_pane_orch.py
@@ -1,0 +1,224 @@
+"""Pilot tests for ``ProjectStatePane`` orchestrator bootstrap.
+
+When Canon starts inside a project that already has a live
+``.orchestrator/master.json``, the pane is expected to:
+
+- reveal itself (``display = True``) once
+  :class:`OrchestratorStateWidget.PlansUpdated` fires,
+- mount a :class:`PlanExecutionSection` and open one tab per plan slug,
+- name the tab pane after the slug (so the agent can address it via the
+  panel-routing layer).
+
+When no plan is active yet — the pane has been configured for plan
+execution but ``master.json`` does not exist — the section must still
+expose an empty-state placeholder so the user can find the feature.
+
+These pilots use a stub model factory so no real orchestrator
+filesystem watcher runs.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.widgets import Static
+
+from toad.widgets.plan_execution_section import PlanExecutionSection
+from toad.widgets.plan_execution_tab import PlanExecutionTab
+from toad.widgets.project_state_pane import ProjectStatePane
+
+
+SLUG = "20260427-test-plan"
+
+
+# ----------------------------------------------------------------------
+# Test doubles
+# ----------------------------------------------------------------------
+
+
+@dataclass
+class _StubModel:
+    """Protocol-shaped stub of ``PlanExecutionModel``.
+
+    The tab only reads the four scalar attributes plus ``subscribe_log``
+    on mount. The pilot does not drive any updates — it just verifies
+    bootstrap geometry — so the stub is intentionally inert.
+    """
+
+    slug: str
+    issue_number: int | None = None
+    items: list[Any] = field(default_factory=list)
+    verdict: str = "running"
+    _unsub_calls: list[int] = field(default_factory=list)
+
+    def subscribe_log(
+        self, item_id: int, callback: Callable[[str], None]
+    ) -> Callable[[], None]:
+        del callback
+
+        def _unsubscribe() -> None:
+            self._unsub_calls.append(item_id)
+
+        return _unsubscribe
+
+
+def _make_factory() -> Callable[[str], _StubModel]:
+    def factory(slug: str) -> _StubModel:
+        return _StubModel(slug=slug, issue_number=99)
+
+    return factory
+
+
+# ----------------------------------------------------------------------
+# Fixtures
+# ----------------------------------------------------------------------
+
+
+def _write_master_json(project_path: Path, slug: str = SLUG) -> Path:
+    """Create a fake ``.orchestrator/master.json`` listing one plan."""
+    plans_dir = project_path / ".orchestrator" / "plans" / slug
+    plans_dir.mkdir(parents=True)
+    state_path = plans_dir / "state.json"
+    state_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "plan": slug,
+                "issueNumber": 99,
+                "items": [
+                    {
+                        "id": 1,
+                        "description": "do work",
+                        "deps": [],
+                        "status": "queued",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    master = project_path / ".orchestrator" / "master.json"
+    master.write_text(
+        json.dumps(
+            {
+                "plans": [
+                    {
+                        "slug": slug,
+                        "status": "running",
+                        "statePath": str(state_path),
+                        "startedAt": "2026-04-27T12:00:00Z",
+                        "updatedAt": "2026-04-27T12:00:00Z",
+                        "progress": {
+                            "total": 1,
+                            "done": 0,
+                            "running": 0,
+                            "failed": 0,
+                        },
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return master
+
+
+# ----------------------------------------------------------------------
+# Harness
+# ----------------------------------------------------------------------
+
+
+class _Harness(App[None]):
+    """App that mounts a single ``ProjectStatePane`` rooted at ``project_path``."""
+
+    def __init__(self, project_path: Path) -> None:
+        super().__init__()
+        self._project_path = project_path
+
+    def compose(self) -> ComposeResult:
+        yield ProjectStatePane(project_path=self._project_path)
+
+
+# ----------------------------------------------------------------------
+# Tests — auto-open on PlansUpdated
+# ----------------------------------------------------------------------
+
+
+class TestPlanExecutionBootstrap:
+    """Pane reveals itself and opens a plan tab when ``master.json`` exists."""
+
+    @pytest.mark.asyncio
+    async def test_pane_visible_after_plans_updated(self, tmp_path: Path) -> None:
+        _write_master_json(tmp_path)
+        app = _Harness(tmp_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            pane = app.query_one(ProjectStatePane)
+            pane.configure_plan_execution(_make_factory())
+            await pilot.pause()
+            await pilot.pause()
+            assert pane.display is True
+
+    @pytest.mark.asyncio
+    async def test_section_is_mounted_with_slug_tab(self, tmp_path: Path) -> None:
+        _write_master_json(tmp_path)
+        app = _Harness(tmp_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            pane = app.query_one(ProjectStatePane)
+            pane.configure_plan_execution(_make_factory())
+            await pilot.pause()
+            await pilot.pause()
+            section = pane.query_one(PlanExecutionSection)
+            assert section.display is True
+            assert SLUG in section.open_slugs
+
+    @pytest.mark.asyncio
+    async def test_tab_id_matches_slug(self, tmp_path: Path) -> None:
+        _write_master_json(tmp_path)
+        app = _Harness(tmp_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            pane = app.query_one(ProjectStatePane)
+            pane.configure_plan_execution(_make_factory())
+            await pilot.pause()
+            await pilot.pause()
+            tab = pane.query_one(PlanExecutionTab)
+            assert tab.id == f"plan-tab-{SLUG}"
+
+
+# ----------------------------------------------------------------------
+# Tests — idle / no-orch state
+# ----------------------------------------------------------------------
+
+
+class TestIdlePlaceholder:
+    """With no ``master.json`` the section shows an empty-state placeholder."""
+
+    @pytest.mark.asyncio
+    async def test_empty_state_visible_before_any_plan(
+        self, tmp_path: Path
+    ) -> None:
+        # No .orchestrator dir at all — pane is in idle state.
+        app = _Harness(tmp_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            pane = app.query_one(ProjectStatePane)
+            pane.configure_plan_execution(_make_factory())
+            await pilot.pause()
+            section = pane.query_one(PlanExecutionSection)
+            placeholders = [
+                node
+                for node in section.query(Static)
+                if "empty-state" in node.classes
+            ]
+            assert placeholders, (
+                "PlanExecutionSection must render an empty-state placeholder "
+                "when no plan is open"
+            )

--- a/tools/verify-tui.py
+++ b/tools/verify-tui.py
@@ -643,6 +643,181 @@ def verify_outreach(verbose: bool = False) -> bool:
     return len(errors) == 0, errors, results
 
 
+def verify_plan_execution(verbose: bool = False) -> bool:
+    """Verify ProjectStatePane auto-opens a plan tab from master.json.
+
+    Writes a fixture project containing ``.orchestrator/master.json`` plus
+    one plan dir, mounts ``ProjectStatePane``, registers a stub model
+    factory, and asserts the pane reveals itself, the plan tab is
+    mounted under the expected id, and the status rail renders one glyph
+    per plan item with the correct running glyph.
+    """
+    import json
+    import tempfile
+    from collections.abc import Callable
+    from pathlib import Path
+
+    from textual.app import App, ComposeResult
+
+    from toad.widgets.plan_dep_graph import DepGraphItem
+    from toad.widgets.plan_execution_section import PlanExecutionSection
+    from toad.widgets.plan_execution_tab import PlanExecutionTab
+    from toad.widgets.plan_status_rail import STATUS_GLYPHS, PlanStatusRail
+    from toad.widgets.project_state_pane import ProjectStatePane
+
+    errors: list[str] = []
+    results: dict[str, object] = {}
+
+    SLUG = "20260427-smoke"
+
+    class _StubModel:
+        def __init__(self, slug: str) -> None:
+            self.slug = slug
+            self.issue_number = 99
+            self.items = [
+                DepGraphItem(
+                    id=1, description="task", status="running", deps=()
+                )
+            ]
+            self.verdict = "running"
+
+        def subscribe_log(
+            self, item_id: int, callback: Callable[[str], None]
+        ) -> Callable[[], None]:
+            del item_id, callback
+            return lambda: None
+
+    def _factory(slug: str) -> _StubModel:
+        return _StubModel(slug)
+
+    def _write_fixture(project: Path) -> None:
+        plans_dir = project / ".orchestrator" / "plans" / SLUG
+        plans_dir.mkdir(parents=True)
+        state_path = plans_dir / "state.json"
+        state_path.write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "plan": SLUG,
+                    "issueNumber": 99,
+                    "items": [
+                        {
+                            "id": 1,
+                            "description": "task",
+                            "deps": [],
+                            "status": "running",
+                        }
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+        (project / ".orchestrator" / "master.json").write_text(
+            json.dumps(
+                {
+                    "plans": [
+                        {
+                            "slug": SLUG,
+                            "status": "running",
+                            "statePath": str(state_path),
+                            "startedAt": "2026-04-27T12:00:00Z",
+                            "updatedAt": "2026-04-27T12:00:00Z",
+                            "progress": {
+                                "total": 1,
+                                "done": 0,
+                                "running": 1,
+                                "failed": 0,
+                            },
+                        }
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    async def _run() -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project = Path(tmp)
+            _write_fixture(project)
+
+            class Harness(App[None]):
+                CSS = "Screen { overflow: hidden; }"
+
+                def compose(self) -> ComposeResult:
+                    yield ProjectStatePane(project_path=project)
+
+            app = Harness()
+            async with app.run_test(size=(120, 40)) as pilot:
+                await pilot.pause()
+                pane = app.query_one(ProjectStatePane)
+                pane.configure_plan_execution(_factory)
+                await pilot.pause()
+                await pilot.pause()
+
+                results["pane_display"] = pane.display
+                if not pane.display:
+                    errors.append(
+                        "ProjectStatePane.display is False after configure_plan_execution"
+                    )
+
+                section = pane.query_one(PlanExecutionSection)
+                results["section_display"] = section.display
+                results["open_slugs"] = sorted(section.open_slugs)
+                if not section.display:
+                    errors.append("PlanExecutionSection hidden after bootstrap")
+                if SLUG not in section.open_slugs:
+                    errors.append(
+                        f"slug {SLUG!r} missing from open_slugs={section.open_slugs}"
+                    )
+
+                tabs = pane.query(PlanExecutionTab)
+                results["tab_count"] = len(tabs)
+                if len(tabs) != 1:
+                    errors.append(
+                        f"expected 1 PlanExecutionTab, found {len(tabs)}"
+                    )
+                else:
+                    tab = tabs.first()
+                    results["tab_id"] = tab.id
+                    expected_id = f"plan-tab-{SLUG}"
+                    if tab.id != expected_id:
+                        errors.append(
+                            f"tab id={tab.id!r}, expected {expected_id!r}"
+                        )
+
+                rails = pane.query(PlanStatusRail)
+                if len(rails) != 1:
+                    errors.append(
+                        f"expected 1 PlanStatusRail, found {len(rails)}"
+                    )
+                else:
+                    rail = rails.first()
+                    glyphs = rail.glyphs_plain()
+                    results["rail_glyphs"] = glyphs
+                    results["rail_verdict"] = rail.verdict_label()
+                    if len(glyphs) != 1:
+                        errors.append(
+                            f"status rail glyph count={len(glyphs)}, expected 1"
+                        )
+                    elif glyphs[0] != STATUS_GLYPHS["running"]:
+                        errors.append(
+                            f"glyph={glyphs[0]!r}, expected running "
+                            f"{STATUS_GLYPHS['running']!r}"
+                        )
+                    if rail.verdict_label() != "running":
+                        errors.append(
+                            f"verdict={rail.verdict_label()!r}, expected 'running'"
+                        )
+
+    asyncio.run(_run())
+
+    if verbose:
+        for key, val in results.items():
+            console.print(f"  {key}: {val}")
+
+    return len(errors) == 0, errors, results
+
+
 def verify_imports(verbose: bool = False) -> bool:
     """Verify all key modules import without error."""
     errors: list[str] = []
@@ -690,6 +865,7 @@ def main() -> None:
             "tasks",
             "subagents",
             "outreach",
+            "plan-execution",
             "live",
             "all",
         ],
@@ -704,6 +880,7 @@ def main() -> None:
         "tasks": verify_tasks,
         "subagents": verify_subagents,
         "outreach": verify_outreach,
+        "plan-execution": verify_plan_execution,
     }
     # Live probe only runs when explicitly requested — it hits the network.
     if args.widget == "live":


### PR DESCRIPTION
## Summary

Closes the gap between the plan-execution widgets (already on canon) and a working "open canon → run orch → see workers" flow.

- Adds `PlanExecutionModel` (`src/toad/data/plan_execution_model.py`) — watches `.orchestrator/plans/<slug>/state.json` and per-item logs, emits `ItemStatusChanged` / `ItemLogAppended` / `PlanFinished`.
- Wires `configure_plan_execution()` in `MainScreen` so `PlanExecutionSection.open_tab(slug)` mounts a tab on `PlansUpdated`.
- `ProjectStatePane._on_plans_updated` reveals the right pane and shows the plan-execution section automatically; adds a `Plans` toolbar button (mounted only when the factory is registered).
- Empty-state placeholder + persistent finished tabs in `PlanExecutionSection`.
- New `verify_plan_execution()` end-to-end smoke in `tools/verify-tui.py`.

## Test plan

- [x] `uv run pytest -q tests/data tests/widgets`
- [x] `uv run python tools/verify-tui.py`
- [x] Manual: `cd /Users/cerratoa/dega/aidd/claude-code-config && canon .` with active `.orchestrator/master.json` shows the plan tab without manual pane-open
- [x] `rg "configure_plan_execution\(" src/ -t py | wc -l` ≥ 2

Closes #37