### PR TITLE
Live updates for PlanExecutionTab — directory watch + interval backstop (closes #39)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ### Changed
+- Live updates for PlanExecutionTab — directory watch + interval backstop (`20260427-plan-tab-live-updates`) — 2026-04-27
+
 - Canon TUI — bootstrap PlanExecutionModel + auto-open plan tab (`20260427-plan-execution-bootstrap`) — 2026-04-27
 
 - Canon TUI view — PlanExecutionTab + dedicated section (`20260422-plan-execution-tab`) — 2026-04-23

--- a/src/toad/data/plan_execution_model.py
+++ b/src/toad/data/plan_execution_model.py
@@ -83,6 +83,10 @@ class PlanExecutionModel:
     # ------------------------------------------------------------------
 
     @property
+    def plan_dir(self) -> Path:
+        return self._plan_dir
+
+    @property
     def slug(self) -> str:
         return self._slug
 

--- a/src/toad/widgets/plan_execution_tab.py
+++ b/src/toad/widgets/plan_execution_tab.py
@@ -23,16 +23,22 @@ it from :class:`PlanExecutionSection`.
 from __future__ import annotations
 
 from collections.abc import Callable, Sequence
+from pathlib import Path
 from typing import Protocol, runtime_checkable
 
 from textual.app import ComposeResult
 from textual.containers import Vertical
 from textual.message import Message
+from textual.timer import Timer
 from textual.widgets import Static, TabPane
 
+from toad.directory_watcher import DirectoryChanged, DirectoryWatcher
 from toad.widgets.plan_dep_graph import DepGraphItem, PlanDepGraph
 from toad.widgets.plan_status_rail import PlanStatusRail, RailItem
 from toad.widgets.plan_worker_log_pane import PlanWorkerLogPane
+
+
+_POLL_INTERVAL_SECONDS = 2.5
 
 
 __all__ = [
@@ -49,11 +55,15 @@ class PlanExecutionModel(Protocol):
     issue_number: int | None
     items: Sequence[DepGraphItem]
     verdict: str
+    plan_dir: Path
 
     def subscribe_log(
         self, item_id: int, callback: Callable[[str], None]
     ) -> Callable[[], None]:
         """Subscribe to a single item's log stream. Returns an unsubscribe."""
+
+    def poll_now(self) -> None:
+        """Rescan the plan directory and post any diffs."""
 
 
 _DEFAULT_AGENT = "—"
@@ -115,6 +125,33 @@ class PlanExecutionTab(TabPane):
         self._items: list[DepGraphItem] = list(model.items)
         self._verdict: str = model.verdict
         self._selected_item_id: int | None = None
+        self._poll_timer: Timer | None = None
+        self._watcher: DirectoryWatcher | None = None
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def on_mount(self) -> None:
+        plan_dir = self._model.plan_dir
+        if plan_dir.is_dir():
+            self._watcher = DirectoryWatcher(plan_dir, self)
+            self._watcher.daemon = True
+            self._watcher.start()
+        self._poll_timer = self.set_interval(
+            _POLL_INTERVAL_SECONDS, self._model.poll_now
+        )
+
+    def on_unmount(self) -> None:
+        if self._watcher is not None:
+            self._watcher.stop()
+            self._watcher = None
+        if self._poll_timer is not None:
+            self._poll_timer.stop()
+            self._poll_timer = None
+
+    def on_directory_changed(self, _event: DirectoryChanged) -> None:
+        self._model.poll_now()
 
     # ------------------------------------------------------------------
     # Compose

--- a/tests/widgets/test_plan_execution_tab.py
+++ b/tests/widgets/test_plan_execution_tab.py
@@ -19,16 +19,21 @@ The tab is intentionally dumb — data arrives through an injected model
 
 from __future__ import annotations
 
+import json
 from collections.abc import Callable
 from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
 
 import pytest
 from textual.app import App, ComposeResult
 from textual.widgets import TabbedContent
 
+from toad.data.plan_execution_model import PlanExecutionModel
+from toad.directory_watcher import DirectoryWatcher
 from toad.widgets.plan_dep_graph import DepGraphItem, PlanDepGraph
 from toad.widgets.plan_execution_tab import PlanExecutionTab
-from toad.widgets.plan_status_rail import PlanStatusRail
+from toad.widgets.plan_status_rail import STATUS_GLYPHS, PlanStatusRail
 from toad.widgets.plan_worker_log_pane import PlanWorkerLogPane
 
 
@@ -224,3 +229,157 @@ class TestPlanFinishedPersists:
             # Still mounted inside the TabbedContent.
             tabs = app.query_one(TabbedContent)
             assert tab.id in {pane.id for pane in tabs.query(PlanExecutionTab)}
+
+
+# ------------------------------------------------------------------
+# Live updates — directory watcher + interval backstop
+# ------------------------------------------------------------------
+
+
+def _state_payload(
+    items: list[dict[str, Any]],
+    *,
+    slug: str = "20260427-live-plan",
+    issue_number: int | None = 99,
+    verdict: str | None = None,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "version": 1,
+        "plan": slug,
+        "issueNumber": issue_number,
+        "items": items,
+    }
+    if verdict is not None:
+        payload["finalReview"] = {"verdict": verdict}
+    return payload
+
+
+def _write_state(plan_dir: Path, payload: dict[str, Any]) -> None:
+    (plan_dir / "state.json").write_text(json.dumps(payload), encoding="utf-8")
+
+
+@pytest.fixture
+def live_plan_dir(tmp_path: Path) -> Path:
+    pdir = tmp_path / ".orchestrator" / "plans" / "20260427-live-plan"
+    (pdir / "logs").mkdir(parents=True)
+    _write_state(
+        pdir,
+        _state_payload(
+            [
+                {"id": 1, "description": "alpha", "deps": [], "status": "queued"},
+                {"id": 2, "description": "beta", "deps": [1], "status": "queued"},
+            ]
+        ),
+    )
+    return pdir
+
+
+class _LateTarget:
+    """Defers ``post_message`` until a real widget is bound after mount."""
+
+    def __init__(self) -> None:
+        self.target: Any = None
+
+    def post_message(self, message: Any) -> bool:
+        if self.target is None:
+            return False
+        return bool(self.target.post_message(message))
+
+
+class _LiveHarness(App[None]):
+    def __init__(self, model: PlanExecutionModel) -> None:
+        super().__init__()
+        self._model = model
+
+    def compose(self) -> ComposeResult:
+        tabs = TabbedContent(id="plan-exec-tabs")
+        with tabs:
+            yield PlanExecutionTab(model=self._model, id="plan-tab-live")
+
+
+class TestLiveUpdates:
+    """Tab installs a watcher + interval on mount; mutations reach the rail."""
+
+    @pytest.mark.asyncio
+    async def test_on_mount_installs_timer_and_watcher(
+        self, live_plan_dir: Path
+    ) -> None:
+        target = _LateTarget()
+        model = PlanExecutionModel(live_plan_dir, target=target)
+        app = _LiveHarness(model)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            tab = app.query_one(PlanExecutionTab)
+            target.target = tab
+
+            # Backstop interval timer is installed.
+            assert tab._poll_timer is not None  # type: ignore[attr-defined]
+            # DirectoryWatcher is installed and points at the plan dir.
+            watcher = tab._watcher  # type: ignore[attr-defined]
+            assert isinstance(watcher, DirectoryWatcher)
+
+    @pytest.mark.asyncio
+    async def test_on_unmount_stops_timer_and_watcher(
+        self, live_plan_dir: Path
+    ) -> None:
+        target = _LateTarget()
+        model = PlanExecutionModel(live_plan_dir, target=target)
+        app = _LiveHarness(model)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            tab = app.query_one(PlanExecutionTab)
+            target.target = tab
+            assert tab._poll_timer is not None  # type: ignore[attr-defined]
+            assert tab._watcher is not None  # type: ignore[attr-defined]
+            tab.remove()
+            await pilot.pause()
+            assert tab._poll_timer is None  # type: ignore[attr-defined]
+            assert tab._watcher is None  # type: ignore[attr-defined]
+
+    @pytest.mark.asyncio
+    async def test_state_mutation_drives_status_change_to_rail(
+        self, live_plan_dir: Path
+    ) -> None:
+        target = _LateTarget()
+        model = PlanExecutionModel(live_plan_dir, target=target)
+        model.start()
+        app = _LiveHarness(model)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            tab = app.query_one(PlanExecutionTab)
+            target.target = tab
+            rail = tab.query_one(PlanStatusRail)
+
+            assert rail.glyphs_plain() == [
+                STATUS_GLYPHS["queued"],
+                STATUS_GLYPHS["queued"],
+            ]
+
+            # Backstop poll catches this even if watcher misses.
+            await pilot.pause()
+            _write_state(
+                live_plan_dir,
+                _state_payload(
+                    [
+                        {
+                            "id": 1,
+                            "description": "alpha",
+                            "deps": [],
+                            "status": "running",
+                        },
+                        {
+                            "id": 2,
+                            "description": "beta",
+                            "deps": [1],
+                            "status": "queued",
+                        },
+                    ]
+                ),
+            )
+            # Allow the 2.5s backstop to fire and the message to drain.
+            await pilot.pause(3.0)
+
+            assert rail.glyphs_plain() == [
+                STATUS_GLYPHS["running"],
+                STATUS_GLYPHS["queued"],
+            ]

--- a/tests/widgets/test_plan_execution_tab.py
+++ b/tests/widgets/test_plan_execution_tab.py
@@ -57,6 +57,7 @@ class _FakeModel:
     issue_number: int | None = 42
     items: list[DepGraphItem] = field(default_factory=list)
     verdict: str = "running"
+    plan_dir: Path = field(default_factory=lambda: Path("/nonexistent-fake-plan"))
     subscriptions: list[_Subscription] = field(default_factory=list)
 
     def subscribe_log(
@@ -69,6 +70,9 @@ class _FakeModel:
             sub.unsubscribed = True
 
         return _unsubscribe
+
+    def poll_now(self) -> None:
+        return None
 
 
 def _fixture_items() -> list[DepGraphItem]:

--- a/tools/verify-tui.py
+++ b/tools/verify-tui.py
@@ -654,65 +654,61 @@ def verify_plan_execution(verbose: bool = False) -> bool:
     """
     import json
     import tempfile
-    from collections.abc import Callable
     from pathlib import Path
+    from typing import Any
 
     from textual.app import App, ComposeResult
 
-    from toad.widgets.plan_dep_graph import DepGraphItem
+    from toad.data.plan_execution_model import PlanExecutionModel
     from toad.widgets.plan_execution_section import PlanExecutionSection
     from toad.widgets.plan_execution_tab import PlanExecutionTab
     from toad.widgets.plan_status_rail import STATUS_GLYPHS, PlanStatusRail
     from toad.widgets.project_state_pane import ProjectStatePane
+
+    class _LateTarget:
+        """Proxies ``post_message`` to a real widget bound after mount."""
+
+        def __init__(self) -> None:
+            self.target: Any = None
+
+        def post_message(self, message: Any) -> bool:
+            if self.target is None:
+                return False
+            return bool(self.target.post_message(message))
+
+    late_target = _LateTarget()
+    built_models: list[PlanExecutionModel] = []
 
     errors: list[str] = []
     results: dict[str, object] = {}
 
     SLUG = "20260427-smoke"
 
-    class _StubModel:
-        def __init__(self, slug: str, plan_dir: Path) -> None:
-            self.slug = slug
-            self.issue_number = 99
-            self.items = [
-                DepGraphItem(
-                    id=1, description="task", status="running", deps=()
-                )
-            ]
-            self.verdict = "running"
-            self.plan_dir = plan_dir
+    def _state_payload(status: str) -> dict[str, object]:
+        return {
+            "version": 1,
+            "plan": SLUG,
+            "issueNumber": 99,
+            "items": [
+                {
+                    "id": 1,
+                    "description": "task",
+                    "deps": [],
+                    "status": status,
+                }
+            ],
+        }
 
-        def subscribe_log(
-            self, item_id: int, callback: Callable[[str], None]
-        ) -> Callable[[], None]:
-            del item_id, callback
-            return lambda: None
-
-        def poll_now(self) -> None:
-            return None
+    def _write_state(plans_dir: Path, status: str) -> None:
+        (plans_dir / "state.json").write_text(
+            json.dumps(_state_payload(status)), encoding="utf-8"
+        )
 
     def _write_fixture(project: Path) -> None:
         plans_dir = project / ".orchestrator" / "plans" / SLUG
-        plans_dir.mkdir(parents=True)
+        (plans_dir / "logs").mkdir(parents=True)
+        _write_state(plans_dir, "running")
         state_path = plans_dir / "state.json"
-        state_path.write_text(
-            json.dumps(
-                {
-                    "version": 1,
-                    "plan": SLUG,
-                    "issueNumber": 99,
-                    "items": [
-                        {
-                            "id": 1,
-                            "description": "task",
-                            "deps": [],
-                            "status": "running",
-                        }
-                    ],
-                }
-            ),
-            encoding="utf-8",
-        )
         (project / ".orchestrator" / "master.json").write_text(
             json.dumps(
                 {
@@ -740,11 +736,7 @@ def verify_plan_execution(verbose: bool = False) -> bool:
         with tempfile.TemporaryDirectory() as tmp:
             project = Path(tmp)
             _write_fixture(project)
-
-            def _factory(slug: str) -> _StubModel:
-                return _StubModel(
-                    slug, project / ".orchestrator" / "plans" / slug
-                )
+            plans_dir = project / ".orchestrator" / "plans" / SLUG
 
             class Harness(App[None]):
                 CSS = "Screen { overflow: hidden; }"
@@ -756,6 +748,16 @@ def verify_plan_execution(verbose: bool = False) -> bool:
             async with app.run_test(size=(120, 40)) as pilot:
                 await pilot.pause()
                 pane = app.query_one(ProjectStatePane)
+
+                def _factory(slug: str) -> PlanExecutionModel | None:
+                    plan_dir = project / ".orchestrator" / "plans" / slug
+                    if not plan_dir.is_dir():
+                        return None
+                    model = PlanExecutionModel(plan_dir, target=late_target)
+                    model.start()
+                    built_models.append(model)
+                    return model
+
                 pane.configure_plan_execution(_factory)
                 await pilot.pause()
                 await pilot.pause()
@@ -790,6 +792,8 @@ def verify_plan_execution(verbose: bool = False) -> bool:
                         errors.append(
                             f"tab id={tab.id!r}, expected {expected_id!r}"
                         )
+                    # Bind the late target so model messages reach the tab.
+                    late_target.target = tab
 
                 rails = pane.query(PlanStatusRail)
                 if len(rails) != 1:
@@ -813,6 +817,25 @@ def verify_plan_execution(verbose: bool = False) -> bool:
                     if rail.verdict_label() != "running":
                         errors.append(
                             f"verdict={rail.verdict_label()!r}, expected 'running'"
+                        )
+
+                    # Mutate state.json — backstop interval (or watcher
+                    # event) should drive an ItemStatusChanged through to
+                    # the rail.
+                    _write_state(plans_dir, "done")
+                    await pilot.pause(3.0)
+
+                    glyphs_after = rail.glyphs_plain()
+                    results["rail_glyphs_after_mutation"] = glyphs_after
+                    if len(glyphs_after) != 1:
+                        errors.append(
+                            f"after mutation glyph count={len(glyphs_after)}, "
+                            f"expected 1"
+                        )
+                    elif glyphs_after[0] != STATUS_GLYPHS["done"]:
+                        errors.append(
+                            f"after mutation glyph={glyphs_after[0]!r}, "
+                            f"expected done {STATUS_GLYPHS['done']!r}"
                         )
 
     asyncio.run(_run())

--- a/tools/verify-tui.py
+++ b/tools/verify-tui.py
@@ -671,7 +671,7 @@ def verify_plan_execution(verbose: bool = False) -> bool:
     SLUG = "20260427-smoke"
 
     class _StubModel:
-        def __init__(self, slug: str) -> None:
+        def __init__(self, slug: str, plan_dir: Path) -> None:
             self.slug = slug
             self.issue_number = 99
             self.items = [
@@ -680,6 +680,7 @@ def verify_plan_execution(verbose: bool = False) -> bool:
                 )
             ]
             self.verdict = "running"
+            self.plan_dir = plan_dir
 
         def subscribe_log(
             self, item_id: int, callback: Callable[[str], None]
@@ -687,8 +688,8 @@ def verify_plan_execution(verbose: bool = False) -> bool:
             del item_id, callback
             return lambda: None
 
-    def _factory(slug: str) -> _StubModel:
-        return _StubModel(slug)
+        def poll_now(self) -> None:
+            return None
 
     def _write_fixture(project: Path) -> None:
         plans_dir = project / ".orchestrator" / "plans" / SLUG
@@ -739,6 +740,11 @@ def verify_plan_execution(verbose: bool = False) -> bool:
         with tempfile.TemporaryDirectory() as tmp:
             project = Path(tmp)
             _write_fixture(project)
+
+            def _factory(slug: str) -> _StubModel:
+                return _StubModel(
+                    slug, project / ".orchestrator" / "plans" / slug
+                )
 
             class Harness(App[None]):
                 CSS = "Screen { overflow: hidden; }"


### PR DESCRIPTION
## Summary

- `PlanExecutionTab.on_mount` now installs a `DirectoryWatcher` on the plan dir plus a 2.5s `set_interval` backstop; both call `model.poll_now()` and are torn down in `on_unmount`.
- `PlanExecutionModel` exposes `plan_dir` as a public attribute; the tab's model protocol slice gains the same.
- `tools/verify-tui.py::verify_plan_execution` now mutates `state.json` after mount and asserts the status rail flips.

Closes #39.

## Test plan

- [ ] `uv run pytest -q tests/widgets/test_plan_execution_tab.py tests/data/test_plan_execution_model.py`
- [ ] `uv run python tools/verify-tui.py`
- [ ] `uv run ruff check src/toad/widgets/plan_execution_tab.py src/toad/data/plan_execution_model.py`
- [ ] `uv run ty check src/toad/widgets/plan_execution_tab.py src/toad/data/plan_execution_model.py`
- [ ] Manual: run `canon .` against an active orch run; rail glyphs flip within ~3s of `state.json` updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)