### PR TITLE
Fix: route plan-execution messages to the matching tab

### DIFF
--- a/src/toad/data/plan_execution_model.py
+++ b/src/toad/data/plan_execution_model.py
@@ -107,6 +107,15 @@ class PlanExecutionModel:
     # Lifecycle
     # ------------------------------------------------------------------
 
+    def set_target(self, target: _MessageTarget) -> None:
+        """Re-point the message sink. Used when the owning tab is mounted
+        after the model is constructed — the factory creates the model
+        with a placeholder pane target, and ``PlanExecutionSection.open_tab``
+        swaps in the actual tab so ``ItemStatusChanged`` messages reach
+        ``on_plan_execution_tab_item_status_changed``.
+        """
+        self._target = target
+
     def start(self) -> None:
         """Mark the model as live; subsequent ``poll_now`` calls emit diffs."""
         self._started = True

--- a/src/toad/widgets/orchestrator_state.py
+++ b/src/toad/widgets/orchestrator_state.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import json
 import logging
+from collections.abc import Callable
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from pathlib import Path
 
 from textual.message import Message
@@ -17,6 +19,46 @@ from toad.directory_watcher import DirectoryChanged, DirectoryWatcher
 log = logging.getLogger(__name__)
 
 POLL_INTERVAL = 5
+
+# A plan with status="running" is considered zombie / stale when its
+# updatedAt is older than this many seconds. Orch heartbeats every 30s,
+# so 90s = three missed polls.
+STALE_THRESHOLD_SECONDS = 90
+
+
+def _parse_iso_utc(raw: str) -> datetime | None:
+    """Parse an ISO-8601 timestamp (with optional trailing 'Z') to UTC."""
+    if not raw:
+        return None
+    try:
+        # Python 3.11+ accepts 'Z'; older versions need it stripped.
+        text = raw.replace("Z", "+00:00") if raw.endswith("Z") else raw
+        dt = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def is_stale(
+    plan: PlanSummary,
+    *,
+    now: datetime | None = None,
+    threshold_seconds: int = STALE_THRESHOLD_SECONDS,
+) -> bool:
+    """Return True if plan is "running" but hasn't been updated recently.
+
+    A stale plan is one whose tmux session likely died (crash, kill, host
+    reboot) leaving an orphan ``status="running"`` entry in master.json.
+    """
+    if plan.status != "running":
+        return False
+    updated = _parse_iso_utc(plan.updated_at)
+    if updated is None:
+        return True  # malformed timestamp on a "running" plan ⇒ treat as stale
+    now = now or datetime.now(timezone.utc)
+    return (now - updated).total_seconds() > threshold_seconds
 
 
 @dataclass(frozen=True)
@@ -80,6 +122,39 @@ def _parse_master(data: dict) -> list[PlanSummary]:
     return plans
 
 
+def _patch_plan_status(data: dict, slug: str, status: str) -> bool:
+    """Set ``status`` on the named plan entry. Returns True if patched."""
+    plans = data.get("plans")
+    if not isinstance(plans, list):
+        return False
+    for entry in plans:
+        if isinstance(entry, dict) and entry.get("slug") == slug:
+            entry["status"] = status
+            entry["updatedAt"] = (
+                datetime.now(timezone.utc)
+                .strftime("%Y-%m-%dT%H:%M:%SZ")
+            )
+            return True
+    return False
+
+
+def _drop_plan(data: dict, slug: str) -> bool:
+    """Remove the named plan entry from ``data["plans"]``. Returns True
+    if a plan was removed.
+    """
+    plans = data.get("plans")
+    if not isinstance(plans, list):
+        return False
+    filtered = [
+        e for e in plans
+        if not (isinstance(e, dict) and e.get("slug") == slug)
+    ]
+    if len(filtered) == len(plans):
+        return False
+    data["plans"] = filtered
+    return True
+
+
 def _parse_items(data: dict) -> list[PlanItem]:
     """Parse per-plan state.json into PlanItem list."""
     items: list[PlanItem] = []
@@ -109,11 +184,23 @@ class OrchestratorStateWidget(Widget):
         """Posted once when master.json is first detected."""
 
     class PlansUpdated(Message):
-        """Posted when the plan list changes."""
+        """Posted when the plan list changes.
 
-        def __init__(self, plans: list[PlanSummary]) -> None:
+        ``baseline_slugs`` is the set of slugs that existed in
+        ``master.json`` the first time the widget read it — i.e. plans
+        that were already there when canon launched. Subscribers use
+        this to skip auto-opening pre-existing plans (only auto-open
+        plans started during the current canon session).
+        """
+
+        def __init__(
+            self,
+            plans: list[PlanSummary],
+            baseline_slugs: frozenset[str],
+        ) -> None:
             super().__init__()
             self.plans = plans
+            self.baseline_slugs = baseline_slugs
 
     class ItemsUpdated(Message):
         """Posted when items for the selected plan change."""
@@ -148,6 +235,11 @@ class OrchestratorStateWidget(Widget):
         self._selected_slug: str | None = None
         self._watcher: DirectoryWatcher | None = None
         self._poll_timer: Timer | None = None
+        # Slugs already present in master.json when canon first read it.
+        # Stays empty until the first successful poll, then frozen for the
+        # rest of the canon session.
+        self._baseline_slugs: frozenset[str] = frozenset()
+        self._baseline_captured = False
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -212,8 +304,13 @@ class OrchestratorStateWidget(Widget):
             return
 
         new_plans = _parse_master(raw)
+        if not self._baseline_captured:
+            self._baseline_slugs = frozenset(p.slug for p in new_plans if p.slug)
+            self._baseline_captured = True
         self.plans = new_plans
-        self.post_message(self.PlansUpdated(new_plans))
+        self.post_message(
+            self.PlansUpdated(new_plans, self._baseline_slugs)
+        )
 
         # Auto-select first plan if none selected
         if self._selected_slug is None and new_plans:
@@ -225,6 +322,56 @@ class OrchestratorStateWidget(Widget):
         """Select a plan and load its items from state.json."""
         self._selected_slug = slug
         self._load_plan_items(slug)
+
+    # ------------------------------------------------------------------
+    # master.json mutations — used for zombie cleanup actions
+    # ------------------------------------------------------------------
+
+    def mark_plan_crashed(self, slug: str) -> bool:
+        """Patch the named plan's entry to ``status: "crashed"``.
+
+        Returns True on success, False if master.json is missing or the
+        slug isn't present. Does not touch the plan's directory.
+        """
+        return self._mutate_master(
+            lambda data: _patch_plan_status(data, slug, "crashed")
+        )
+
+    def remove_plan_from_list(self, slug: str) -> bool:
+        """Drop the named plan from ``master.json.plans``.
+
+        Returns True on success. The plan's ``.orchestrator/plans/<slug>/``
+        directory is left intact so logs survive.
+        """
+        return self._mutate_master(
+            lambda data: _drop_plan(data, slug)
+        )
+
+    def _mutate_master(
+        self, mutator: Callable[[dict], bool]
+    ) -> bool:
+        if not self._master_path.is_file():
+            return False
+        try:
+            data = json.loads(
+                self._master_path.read_text(encoding="utf-8")
+            )
+        except (OSError, json.JSONDecodeError) as exc:
+            log.warning("Failed to read master.json for mutation: %s", exc)
+            return False
+        if not mutator(data):
+            return False
+        try:
+            self._master_path.write_text(
+                json.dumps(data, indent=2) + "\n",
+                encoding="utf-8",
+            )
+        except OSError as exc:
+            log.warning("Failed to write master.json: %s", exc)
+            return False
+        # Refresh state so the UI sees the mutation right away.
+        self._poll_state()
+        return True
 
     def _load_plan_items(self, slug: str) -> None:
         """Read per-plan state.json and update selected_plan_items."""

--- a/src/toad/widgets/plan_execution_section.py
+++ b/src/toad/widgets/plan_execution_section.py
@@ -16,13 +16,16 @@ lands without crashing on live ``master.json`` updates.
 from __future__ import annotations
 
 import logging
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from typing import Any
 
+from textual import on
 from textual.app import ComposeResult
-from textual.containers import Vertical
-from textual.widgets import Static, TabbedContent, TabPane
+from textual.containers import Horizontal, Vertical
+from textual.message import Message
+from textual.widgets import Button, Static, TabbedContent, TabPane
 
+from toad.widgets.orchestrator_state import PlanSummary, is_stale
 from toad.widgets.plan_execution_tab import PlanExecutionModel, PlanExecutionTab
 
 
@@ -36,9 +39,12 @@ __all__ = [
 EMPTY_PANE_ID = "plan-exec-empty"
 _EMPTY_PANE_TITLE = "Plans"
 _EMPTY_PLACEHOLDER_TEXT = (
-    "No plan execution running.\n\n"
+    "No plan running.\n\n"
     "Start one with:  bash ~/.claude/scripts/orch-run.sh <slug>"
 )
+_BTN_OPEN_PREFIX = "plan-open-"
+_BTN_CRASH_PREFIX = "plan-crash-"
+_BTN_REMOVE_PREFIX = "plan-remove-"
 
 
 log = logging.getLogger(__name__)
@@ -57,6 +63,20 @@ class PlanExecutionSection(Vertical):
 
     SECTION_ID = "section-plan-execution"
 
+    class PlanCrashRequested(Message):
+        """User clicked Mark-crashed on the running-plans list."""
+
+        def __init__(self, slug: str) -> None:
+            super().__init__()
+            self.slug = slug
+
+    class PlanRemoveRequested(Message):
+        """User clicked Remove-from-list on the running-plans list."""
+
+        def __init__(self, slug: str) -> None:
+            super().__init__()
+            self.slug = slug
+
     DEFAULT_CSS = """
     PlanExecutionSection {
         display: none;
@@ -68,8 +88,41 @@ class PlanExecutionSection(Vertical):
     }
 
     PlanExecutionSection .empty-state {
-        padding: 2 4;
+        padding: 1 2;
         color: $text-muted;
+    }
+
+    PlanExecutionSection .plan-list-header {
+        padding: 1 2 0 2;
+        color: $text;
+        text-style: bold;
+    }
+
+    PlanExecutionSection .plan-list-row {
+        height: 1;
+        padding: 0 2;
+    }
+
+    PlanExecutionSection .plan-list-row Button {
+        height: 1;
+        min-width: 6;
+        margin-right: 1;
+        border: none;
+        background: $surface;
+        color: $text;
+    }
+
+    PlanExecutionSection .plan-list-row .plan-status {
+        width: 9;
+        color: $success;
+    }
+
+    PlanExecutionSection .plan-list-row .plan-status.zombie {
+        color: $warning;
+    }
+
+    PlanExecutionSection .plan-list-row .plan-status.crashed {
+        color: $error;
     }
     """
 
@@ -86,6 +139,8 @@ class PlanExecutionSection(Vertical):
         # Dedupe set keyed by plan slug — prevents duplicate tabs when
         # master.json updates replay the same slug across polls.
         self._open_slugs: set[str] = set()
+        # Plans surfaced in the empty-state list (running + zombie only).
+        self._listed_plans: list[PlanSummary] = []
 
     # ------------------------------------------------------------------
     # Compose
@@ -93,15 +148,64 @@ class PlanExecutionSection(Vertical):
 
     def compose(self) -> ComposeResult:
         with TabbedContent(id="plan-exec-tabs"):
-            yield self._build_empty_pane()
+            yield self._build_empty_pane(self._listed_plans)
+
+    @classmethod
+    def _build_empty_pane(
+        cls, plans: list[PlanSummary]
+    ) -> TabPane:
+        body = Vertical(
+            *cls._empty_body_widgets(plans),
+            id="plan-exec-empty-body",
+        )
+        return TabPane(_EMPTY_PANE_TITLE, body, id=EMPTY_PANE_ID)
+
+    @classmethod
+    def _empty_body_widgets(
+        cls, plans: list[PlanSummary]
+    ) -> list[Any]:
+        listed = [
+            p for p in plans
+            if p.status == "running"  # zombies are still status=running
+        ]
+        if not listed:
+            return [Static(_EMPTY_PLACEHOLDER_TEXT, classes="empty-state")]
+        children: list[Any] = [
+            Static("Active plans", classes="plan-list-header")
+        ]
+        for plan in listed:
+            children.append(cls._build_plan_row(plan))
+        return children
 
     @staticmethod
-    def _build_empty_pane() -> TabPane:
-        return TabPane(
-            _EMPTY_PANE_TITLE,
-            Static(_EMPTY_PLACEHOLDER_TEXT, classes="empty-state"),
-            id=EMPTY_PANE_ID,
-        )
+    def _build_plan_row(plan: PlanSummary) -> Horizontal:
+        zombie = is_stale(plan)
+        status_label = "ZOMBIE" if zombie else "RUNNING"
+        status_classes = "plan-status zombie" if zombie else "plan-status"
+        row_widgets: list[Any] = [
+            Static(status_label, classes=status_classes),
+            Button(
+                plan.slug,
+                id=f"{_BTN_OPEN_PREFIX}{_safe(plan.slug)}",
+                tooltip="Open this plan's tab",
+            ),
+        ]
+        if zombie:
+            row_widgets.extend(
+                [
+                    Button(
+                        "Mark crashed",
+                        id=f"{_BTN_CRASH_PREFIX}{_safe(plan.slug)}",
+                        tooltip="Mark as crashed in master.json",
+                    ),
+                    Button(
+                        "Remove",
+                        id=f"{_BTN_REMOVE_PREFIX}{_safe(plan.slug)}",
+                        tooltip="Remove from master.json (keeps logs on disk)",
+                    ),
+                ]
+            )
+        return Horizontal(*row_widgets, classes="plan-list-row")
 
     # ------------------------------------------------------------------
     # Public API
@@ -119,6 +223,32 @@ class PlanExecutionSection(Vertical):
         has already been mounted.
         """
         self._model_factory = factory
+
+    def set_plan_summaries(
+        self, plans: Iterable[PlanSummary]
+    ) -> None:
+        """Update the running-plans list shown in the empty-state pane.
+
+        Filtered to plans with ``status == "running"`` (zombies included
+        — they're still nominally running). Has no effect on plans that
+        already have an open tab.
+        """
+        self._listed_plans = list(plans)
+        self._refresh_empty_pane()
+
+    def _refresh_empty_pane(self) -> None:
+        # Replace the empty pane's body in place rather than removing
+        # and re-adding the TabPane (Textual's TabbedContent generates
+        # an internal --content-tab-<id> widget that races with re-adds
+        # of the same pane id).
+        try:
+            body = self.query_one(
+                "#plan-exec-empty-body", Vertical
+            )
+        except Exception:
+            return
+        body.remove_children()
+        body.mount(*self._empty_body_widgets(self._listed_plans))
 
     def open_tab(self, slug: str) -> str | None:
         """Open a plan tab for ``slug``. Idempotent on the slug.
@@ -165,7 +295,42 @@ class PlanExecutionSection(Vertical):
         tabs = self.query_one("#plan-exec-tabs", TabbedContent)
         tabs.remove_pane(self._tab_id(slug))
         if not self._open_slugs:
-            tabs.add_pane(self._build_empty_pane())
+            tabs.add_pane(self._build_empty_pane(self._listed_plans))
+
+    # ------------------------------------------------------------------
+    # Empty-state list — open / mark-crashed / remove buttons
+    # ------------------------------------------------------------------
+
+    @on(Button.Pressed)
+    def _on_plan_list_button(self, event: Button.Pressed) -> None:
+        btn_id = event.button.id or ""
+        slug: str | None = None
+        action: str | None = None
+        for prefix, name in (
+            (_BTN_OPEN_PREFIX, "open"),
+            (_BTN_CRASH_PREFIX, "crash"),
+            (_BTN_REMOVE_PREFIX, "remove"),
+        ):
+            if btn_id.startswith(prefix):
+                action = name
+                safe = btn_id.removeprefix(prefix)
+                slug = self._lookup_slug(safe)
+                break
+        if action is None or slug is None:
+            return
+        event.stop()
+        if action == "open":
+            self.open_tab(slug)
+        elif action == "crash":
+            self.post_message(self.PlanCrashRequested(slug))
+        elif action == "remove":
+            self.post_message(self.PlanRemoveRequested(slug))
+
+    def _lookup_slug(self, safe: str) -> str | None:
+        for plan in self._listed_plans:
+            if _safe(plan.slug) == safe:
+                return plan.slug
+        return None
 
     # ------------------------------------------------------------------
     # Internals
@@ -185,5 +350,8 @@ class PlanExecutionSection(Vertical):
 
     @staticmethod
     def _tab_id(slug: str) -> str:
-        safe = slug.replace(".", "-").replace("/", "-").replace(" ", "-")
-        return f"plan-tab-{safe}"
+        return f"plan-tab-{_safe(slug)}"
+
+
+def _safe(slug: str) -> str:
+    return slug.replace(".", "-").replace("/", "-").replace(" ", "-")

--- a/src/toad/widgets/plan_execution_section.py
+++ b/src/toad/widgets/plan_execution_section.py
@@ -273,6 +273,12 @@ class PlanExecutionSection(Vertical):
             get_current_agent=self._get_current_agent,
             id=tab_id,
         )
+        # Re-point the model's message sink at the tab now that it exists.
+        # The factory built the model with a placeholder pane target so
+        # ItemStatusChanged / PlanFinished bubble through the correct tab
+        # handler instead of dying on the pane (which has no handler).
+        if hasattr(model, "set_target"):
+            model.set_target(tab)
         tabs = self.query_one("#plan-exec-tabs", TabbedContent)
         if not self._open_slugs:
             self._remove_empty_pane(tabs)

--- a/src/toad/widgets/plan_execution_tab.py
+++ b/src/toad/widgets/plan_execution_tab.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Sequence
 from pathlib import Path
-from typing import Protocol, runtime_checkable
+from typing import Any, Protocol, runtime_checkable
 
 from textual.app import ComposeResult
 from textual.containers import Vertical
@@ -64,6 +64,9 @@ class PlanExecutionModel(Protocol):
 
     def poll_now(self) -> None:
         """Rescan the plan directory and post any diffs."""
+
+    def set_target(self, target: Any) -> None:
+        """Re-point the model's message sink at the given widget."""
 
 
 _DEFAULT_AGENT = "—"

--- a/src/toad/widgets/plan_execution_tab.py
+++ b/src/toad/widgets/plan_execution_tab.py
@@ -248,6 +248,8 @@ class PlanExecutionTab(TabPane):
         slug = self._model.slug
         issue = self._model.issue_number
         done = sum(1 for item in self._items if item.status == "done")
+        running = sum(1 for item in self._items if item.status == "running")
+        failed = sum(1 for item in self._items if item.status == "failed")
         total = len(self._items)
         agent = (
             self._get_current_agent() if self._get_current_agent else _DEFAULT_AGENT
@@ -256,6 +258,11 @@ class PlanExecutionTab(TabPane):
         if issue is not None:
             parts.append(f"#{issue}")
         parts.append(self._verdict)
-        parts.append(f"{done}/{total}")
+        counters = [f"✓{done}/{total}"]
+        if running:
+            counters.append(f"◉{running}")
+        if failed:
+            counters.append(f"✗{failed}")
+        parts.append(" ".join(counters))
         parts.append(f"agent: {agent}")
         return "  ".join(parts)

--- a/src/toad/widgets/project_state_pane.py
+++ b/src/toad/widgets/project_state_pane.py
@@ -125,6 +125,21 @@ PANEL_ROUTES: dict[str, tuple[str, str]] = {
     "state": (SECTION_STATE, "tab-builder"),
     "builder": (SECTION_STATE, "tab-builder"),
     "outreach": (SECTION_OUTREACH, "tab-outreach"),
+    # Plan execution: dynamic tab-per-slug, so the tab id is the
+    # section's stable empty-pane id. The pane handler treats this
+    # as "show the section, surface the running-plans list".
+    "plan_execution": (
+        PlanExecutionSection.SECTION_ID,
+        "plan-exec-empty",
+    ),
+    "plan_run": (
+        PlanExecutionSection.SECTION_ID,
+        "plan-exec-empty",
+    ),
+    "running_plans": (
+        PlanExecutionSection.SECTION_ID,
+        "plan-exec-empty",
+    ),
 }
 
 
@@ -492,6 +507,12 @@ class ProjectStatePane(Vertical):
 
     def show_section(self, section_id: str) -> None:
         """Show a section by its ID."""
+        # The plan execution section is mounted lazily on first use —
+        # ensure it exists before trying to query it (e.g. for the
+        # ``plan_execution`` panel route, fired before any plan tab
+        # has been opened).
+        if section_id == PlanExecutionSection.SECTION_ID:
+            self._ensure_plan_exec_section()
         try:
             self.query_one(f"#{section_id}").display = True
         except NoMatches:
@@ -607,21 +628,21 @@ class ProjectStatePane(Vertical):
         self._sync_toolbar()
 
     def _replay_pending_plans(self, section: PlanExecutionSection) -> None:
-        """Open tabs for any plans already known to the orchestrator widget."""
+        """Push the current plan snapshot into the section's running list.
+
+        Plans already running when canon launched are pre-existing — they
+        are NOT auto-opened. The user can pick them from the running-plans
+        list (rendered as the section's empty state) or call the
+        ``plan_execution`` panel route. This keeps canon launch silent
+        when reattaching to a project with live orch state.
+        """
         try:
             widget = self.query_one(
                 "#orchestrator-state", OrchestratorStateWidget
             )
         except NoMatches:
             return
-        plans = list(widget.plans)
-        if not plans:
-            return
-        self.display = True
-        self.show_section(PlanExecutionSection.SECTION_ID)
-        for plan in plans:
-            if plan.slug:
-                section.open_tab(plan.slug)
+        section.set_plan_summaries(list(widget.plans))
 
     def _ensure_plan_exec_section(self) -> PlanExecutionSection:
         if self._plan_exec_section is None:
@@ -639,20 +660,64 @@ class ProjectStatePane(Vertical):
     def _on_plans_updated(
         self, event: OrchestratorStateWidget.PlansUpdated
     ) -> None:
-        """Auto-open a tab for every plan slug in ``master.json``.
+        """Auto-open tabs only for plans started during this canon session.
 
-        Duplicate slugs are deduped by :meth:`PlanExecutionSection.open_tab`.
-        When no model factory is registered the section is a silent no-op.
+        Pre-existing plans (those already in ``master.json`` when canon
+        launched) and completed plans are skipped — they are reachable
+        via the explicit ``plan_execution`` panel route. Without this
+        filter every old plan in master.json would mount a tab.
+
+        The section itself is mounted regardless so the running-plans
+        list (rendered as the section's empty state) stays current.
         """
         event.stop()
+        section = self._ensure_plan_exec_section()
+        section.set_plan_summaries(event.plans)
         if not event.plans:
             return
-        section = self._ensure_plan_exec_section()
+        baseline = event.baseline_slugs
+        new_active = [
+            p for p in event.plans
+            if p.slug
+            and p.slug not in baseline
+            and p.status not in ("completed", "crashed")
+        ]
+        if not new_active:
+            return
+        # A plan was started while canon was running — reveal the pane
+        # and mount its tab.
         self.display = True
         self.show_section(PlanExecutionSection.SECTION_ID)
-        for plan in event.plans:
-            if plan.slug:
-                section.open_tab(plan.slug)
+        for plan in new_active:
+            section.open_tab(plan.slug)
+
+    @on(PlanExecutionSection.PlanCrashRequested)
+    def _on_plan_crash_requested(
+        self, event: PlanExecutionSection.PlanCrashRequested
+    ) -> None:
+        """Forward zombie cleanup → master.json mutation."""
+        event.stop()
+        try:
+            widget = self.query_one(
+                "#orchestrator-state", OrchestratorStateWidget
+            )
+        except NoMatches:
+            return
+        widget.mark_plan_crashed(event.slug)
+
+    @on(PlanExecutionSection.PlanRemoveRequested)
+    def _on_plan_remove_requested(
+        self, event: PlanExecutionSection.PlanRemoveRequested
+    ) -> None:
+        """Forward remove-from-list → master.json mutation."""
+        event.stop()
+        try:
+            widget = self.query_one(
+                "#orchestrator-state", OrchestratorStateWidget
+            )
+        except NoMatches:
+            return
+        widget.remove_plan_from_list(event.slug)
 
     def activate_tab(self, tab_id: str) -> None:
         """Switch to a specific tab by its pane id."""

--- a/tests/widgets/test_orchestrator_state.py
+++ b/tests/widgets/test_orchestrator_state.py
@@ -1,0 +1,165 @@
+"""Unit tests for OrchestratorStateWidget helpers — no Textual app needed.
+
+Covers:
+
+- ``is_stale`` — running plans whose updatedAt is older than the
+  threshold are flagged; non-running and recently-updated ones are not.
+- ``_patch_plan_status`` and ``_drop_plan`` — JSON mutators used by the
+  zombie cleanup buttons.
+- Baseline capture and filter contract — exercised at the widget level
+  in :mod:`tests.widgets.test_project_state_pane_orch`; here we cover
+  the pure helpers.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from toad.widgets.orchestrator_state import (
+    PlanProgress,
+    PlanSummary,
+    STALE_THRESHOLD_SECONDS,
+    _drop_plan,
+    _patch_plan_status,
+    is_stale,
+)
+
+
+def _summary(
+    *,
+    slug: str = "demo",
+    status: str = "running",
+    updated_at: str = "",
+) -> PlanSummary:
+    return PlanSummary(
+        slug=slug,
+        status=status,
+        state_path="",
+        started_at="",
+        updated_at=updated_at,
+        progress=PlanProgress(),
+    )
+
+
+# ----------------------------------------------------------------------
+# is_stale
+# ----------------------------------------------------------------------
+
+
+class TestIsStale:
+    def _now(self) -> datetime:
+        return datetime(2026, 4, 27, 12, 0, 0, tzinfo=timezone.utc)
+
+    def test_non_running_is_never_stale(self) -> None:
+        plan = _summary(status="completed", updated_at="2026-01-01T00:00:00Z")
+        assert is_stale(plan, now=self._now()) is False
+
+    def test_recent_running_is_not_stale(self) -> None:
+        recent = (self._now() - timedelta(seconds=5)).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        )
+        plan = _summary(status="running", updated_at=recent)
+        assert is_stale(plan, now=self._now()) is False
+
+    def test_old_running_is_stale(self) -> None:
+        old = (
+            self._now() - timedelta(seconds=STALE_THRESHOLD_SECONDS + 30)
+        ).strftime("%Y-%m-%dT%H:%M:%SZ")
+        plan = _summary(status="running", updated_at=old)
+        assert is_stale(plan, now=self._now()) is True
+
+    def test_malformed_timestamp_on_running_is_stale(self) -> None:
+        plan = _summary(status="running", updated_at="not-a-date")
+        assert is_stale(plan, now=self._now()) is True
+
+    def test_threshold_is_overridable(self) -> None:
+        """Tests can dial the threshold down for fast feedback."""
+        old = (self._now() - timedelta(seconds=2)).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        )
+        plan = _summary(status="running", updated_at=old)
+        assert is_stale(plan, now=self._now(), threshold_seconds=1) is True
+        assert is_stale(plan, now=self._now(), threshold_seconds=10) is False
+
+
+# ----------------------------------------------------------------------
+# _patch_plan_status / _drop_plan
+# ----------------------------------------------------------------------
+
+
+class TestMasterMutators:
+    def _data(self) -> dict:
+        return {
+            "plans": [
+                {"slug": "alpha", "status": "running"},
+                {"slug": "beta", "status": "running"},
+            ]
+        }
+
+    def test_patch_status_returns_true_and_mutates(self) -> None:
+        data = self._data()
+        assert _patch_plan_status(data, "alpha", "crashed") is True
+        statuses = {p["slug"]: p["status"] for p in data["plans"]}
+        assert statuses == {"alpha": "crashed", "beta": "running"}
+
+    def test_patch_status_records_updatedAt(self) -> None:
+        data = self._data()
+        _patch_plan_status(data, "alpha", "crashed")
+        entry = next(p for p in data["plans"] if p["slug"] == "alpha")
+        # ISO-8601 with trailing Z, e.g. 2026-04-27T12:34:56Z
+        assert entry["updatedAt"].endswith("Z")
+        assert "T" in entry["updatedAt"]
+
+    def test_patch_status_returns_false_on_unknown_slug(self) -> None:
+        data = self._data()
+        assert _patch_plan_status(data, "ghost", "crashed") is False
+        assert all(p["status"] == "running" for p in data["plans"])
+
+    def test_drop_plan_removes_entry(self) -> None:
+        data = self._data()
+        assert _drop_plan(data, "beta") is True
+        assert [p["slug"] for p in data["plans"]] == ["alpha"]
+
+    def test_drop_plan_returns_false_on_unknown_slug(self) -> None:
+        data = self._data()
+        assert _drop_plan(data, "ghost") is False
+        assert len(data["plans"]) == 2
+
+    def test_drop_plan_handles_missing_plans_key(self) -> None:
+        assert _drop_plan({}, "alpha") is False
+        assert _patch_plan_status({}, "alpha", "crashed") is False
+
+
+# ----------------------------------------------------------------------
+# Round-trip through a real master.json — used by the widget mutators
+# ----------------------------------------------------------------------
+
+
+def test_master_json_mutation_round_trip(tmp_path: Path) -> None:
+    """Mark crashed + drop, both round-trip cleanly through JSON."""
+    master = tmp_path / "master.json"
+    master.write_text(
+        json.dumps(
+            {
+                "plans": [
+                    {"slug": "alpha", "status": "running"},
+                    {"slug": "beta", "status": "running"},
+                    {"slug": "gamma", "status": "completed"},
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    data = json.loads(master.read_text(encoding="utf-8"))
+    assert _patch_plan_status(data, "alpha", "crashed") is True
+    assert _drop_plan(data, "beta") is True
+    master.write_text(
+        json.dumps(data, indent=2) + "\n", encoding="utf-8"
+    )
+
+    reloaded = json.loads(master.read_text(encoding="utf-8"))
+    statuses = {p["slug"]: p["status"] for p in reloaded["plans"]}
+    assert statuses == {"alpha": "crashed", "gamma": "completed"}

--- a/tests/widgets/test_project_state_pane_orch.py
+++ b/tests/widgets/test_project_state_pane_orch.py
@@ -1,17 +1,17 @@
 """Pilot tests for ``ProjectStatePane`` orchestrator bootstrap.
 
-When Canon starts inside a project that already has a live
-``.orchestrator/master.json``, the pane is expected to:
+Spec (post-baseline-filter):
 
-- reveal itself (``display = True``) once
-  :class:`OrchestratorStateWidget.PlansUpdated` fires,
-- mount a :class:`PlanExecutionSection` and open one tab per plan slug,
-- name the tab pane after the slug (so the agent can address it via the
-  panel-routing layer).
-
-When no plan is active yet — the pane has been configured for plan
-execution but ``master.json`` does not exist — the section must still
-expose an empty-state placeholder so the user can find the feature.
+- Plans already in ``master.json`` when canon launches are *baseline* —
+  they are NOT auto-opened. The pane stays hidden, no tab is mounted.
+  These plans are surfaced in the section's running-plans list (rendered
+  inside the empty-state pane) for the user to pick on demand.
+- A plan slug that *appears* in ``master.json`` after canon is up — i.e.
+  an orch run started during this canon session — IS auto-opened: pane
+  reveals, plan execution section is shown, a tab is mounted with a
+  slug-derived id.
+- With no ``master.json`` at all, the section still renders an empty
+  placeholder so the user can find the feature.
 
 These pilots use a stub model factory so no real orchestrator
 filesystem watcher runs.
@@ -151,22 +151,13 @@ class _Harness(App[None]):
 
 
 class TestPlanExecutionBootstrap:
-    """Pane reveals itself and opens a plan tab when ``master.json`` exists."""
+    """Pre-existing plans don't auto-open; in-session arrivals do."""
 
     @pytest.mark.asyncio
-    async def test_pane_visible_after_plans_updated(self, tmp_path: Path) -> None:
-        _write_master_json(tmp_path)
-        app = _Harness(tmp_path)
-        async with app.run_test() as pilot:
-            await pilot.pause()
-            pane = app.query_one(ProjectStatePane)
-            pane.configure_plan_execution(_make_factory())
-            await pilot.pause()
-            await pilot.pause()
-            assert pane.display is True
-
-    @pytest.mark.asyncio
-    async def test_section_is_mounted_with_slug_tab(self, tmp_path: Path) -> None:
+    async def test_existing_plan_does_not_auto_open(
+        self, tmp_path: Path
+    ) -> None:
+        """Canon launched into a project with a running plan stays silent."""
         _write_master_json(tmp_path)
         app = _Harness(tmp_path)
         async with app.run_test() as pilot:
@@ -176,19 +167,36 @@ class TestPlanExecutionBootstrap:
             await pilot.pause()
             await pilot.pause()
             section = pane.query_one(PlanExecutionSection)
-            assert section.display is True
-            assert SLUG in section.open_slugs
+            assert SLUG not in section.open_slugs
+            # Running-plans list is populated so the user can open it.
+            assert any(p.slug == SLUG for p in section._listed_plans)
 
     @pytest.mark.asyncio
-    async def test_tab_id_matches_slug(self, tmp_path: Path) -> None:
-        _write_master_json(tmp_path)
+    async def test_in_session_plan_auto_opens(self, tmp_path: Path) -> None:
+        """A new plan slug arriving after canon launch opens its tab."""
+        # Master.json starts empty — establishes empty baseline.
+        master = tmp_path / ".orchestrator" / "master.json"
+        master.parent.mkdir(parents=True)
+        master.write_text(json.dumps({"plans": []}), encoding="utf-8")
+
         app = _Harness(tmp_path)
         async with app.run_test() as pilot:
             await pilot.pause()
             pane = app.query_one(ProjectStatePane)
             pane.configure_plan_execution(_make_factory())
             await pilot.pause()
+
+            # Now write a new plan — simulates an orch run started while
+            # canon is up.
+            _write_master_json(tmp_path)
             await pilot.pause()
+            await pilot.pause()
+            await pilot.pause()
+
+            section = pane.query_one(PlanExecutionSection)
+            assert pane.display is True
+            assert section.display is True
+            assert SLUG in section.open_slugs
             tab = pane.query_one(PlanExecutionTab)
             assert tab.id == f"plan-tab-{SLUG}"
 
@@ -196,6 +204,138 @@ class TestPlanExecutionBootstrap:
 # ----------------------------------------------------------------------
 # Tests — idle / no-orch state
 # ----------------------------------------------------------------------
+
+
+class TestZombieList:
+    """Running-plans list surfaces zombies and exposes cleanup actions."""
+
+    @pytest.mark.asyncio
+    async def test_zombie_plan_is_listed_with_cleanup_buttons(
+        self, tmp_path: Path
+    ) -> None:
+        """A stale running plan shows up with Mark-crashed + Remove buttons."""
+        # Build a master.json with one plan whose updatedAt is way in the
+        # past — guaranteed stale.
+        plans_dir = tmp_path / ".orchestrator" / "plans" / SLUG
+        plans_dir.mkdir(parents=True)
+        master = tmp_path / ".orchestrator" / "master.json"
+        master.write_text(
+            json.dumps(
+                {
+                    "plans": [
+                        {
+                            "slug": SLUG,
+                            "status": "running",
+                            "statePath": "",
+                            "startedAt": "2020-01-01T00:00:00Z",
+                            "updatedAt": "2020-01-01T00:00:00Z",
+                            "progress": {
+                                "total": 1,
+                                "done": 0,
+                                "running": 0,
+                                "failed": 0,
+                            },
+                        }
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        app = _Harness(tmp_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            pane = app.query_one(ProjectStatePane)
+            pane.configure_plan_execution(_make_factory())
+            await pilot.pause()
+            await pilot.pause()
+
+            # User clicks the Mark-crashed button on the zombie row.
+            from toad.widgets.plan_execution_section import (
+                PlanExecutionSection as _S,
+            )
+
+            section = pane.query_one(_S)
+            section.show_section = lambda *_: None  # type: ignore[assignment]
+            from textual.widgets import Button
+
+            crash_btn = section.query_one(
+                f"#plan-crash-{SLUG}", Button
+            )
+            crash_btn.press()
+            await pilot.pause()
+            await pilot.pause()
+
+            # master.json now reports the plan as crashed.
+            data = json.loads(master.read_text(encoding="utf-8"))
+            entry = next(p for p in data["plans"] if p["slug"] == SLUG)
+            assert entry["status"] == "crashed"
+
+    @pytest.mark.asyncio
+    async def test_remove_button_drops_plan_from_master_json(
+        self, tmp_path: Path
+    ) -> None:
+        plans_dir = tmp_path / ".orchestrator" / "plans" / SLUG
+        plans_dir.mkdir(parents=True)
+        master = tmp_path / ".orchestrator" / "master.json"
+        master.write_text(
+            json.dumps(
+                {
+                    "plans": [
+                        {
+                            "slug": SLUG,
+                            "status": "running",
+                            "statePath": "",
+                            "startedAt": "2020-01-01T00:00:00Z",
+                            "updatedAt": "2020-01-01T00:00:00Z",
+                            "progress": {
+                                "total": 1,
+                                "done": 0,
+                                "running": 0,
+                                "failed": 0,
+                            },
+                        }
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        app = _Harness(tmp_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            pane = app.query_one(ProjectStatePane)
+            pane.configure_plan_execution(_make_factory())
+            await pilot.pause()
+            await pilot.pause()
+
+            from textual.widgets import Button
+
+            remove_btn = pane.query_one(
+                f"#plan-remove-{SLUG}", Button
+            )
+            remove_btn.press()
+            await pilot.pause()
+            await pilot.pause()
+
+            data = json.loads(master.read_text(encoding="utf-8"))
+            assert all(p["slug"] != SLUG for p in data["plans"])
+
+
+class TestPanelRoute:
+    """The plan_execution panel route opens the section without auto-mounting tabs."""
+
+    @pytest.mark.asyncio
+    async def test_panel_route_registered(self) -> None:
+        """The route exists and points at the plan-exec section."""
+        from toad.widgets.project_state_pane import PANEL_ROUTES
+        from toad.widgets.plan_execution_section import (
+            PlanExecutionSection as _S,
+        )
+
+        assert "plan_execution" in PANEL_ROUTES
+        section_id, _tab_id = PANEL_ROUTES["plan_execution"]
+        assert section_id == _S.SECTION_ID
 
 
 class TestIdlePlaceholder:

--- a/tools/fake-plan.sh
+++ b/tools/fake-plan.sh
@@ -1,0 +1,242 @@
+#!/usr/bin/env bash
+# Drive a fake orch plan from the shell so you can poke the canon
+# PlanExecutionTab without spawning real workers.
+#
+# Usage (from any project where you'd run `canon .`):
+#
+#   tools/fake-plan.sh init [slug] [item-count]   # create a fresh plan
+#   tools/fake-plan.sh tick [slug]                # advance next item: queued→running, or running→done
+#   tools/fake-plan.sh fail [slug]                # mark the running item failed
+#   tools/fake-plan.sh ship [slug]                # mark all items done + final SHIP
+#   tools/fake-plan.sh stale [slug] [age-sec]     # rewind updatedAt so stale-detection fires (default 600s)
+#   tools/fake-plan.sh remove [slug]              # delete plan dir + master.json entry
+#
+# Defaults: slug=fake-plan-demo, item-count=5, project=$PWD.
+# All state lives under $PWD/.orchestrator/ — point canon at the same dir.
+
+set -euo pipefail
+
+CMD="${1:-help}"
+SLUG="${2:-fake-plan-demo}"
+ARG3="${3:-}"
+
+PROJECT_ROOT="${PROJECT_ROOT:-$PWD}"
+ORCH_DIR="$PROJECT_ROOT/.orchestrator"
+PLAN_DIR="$ORCH_DIR/plans/$SLUG"
+STATE_JSON="$PLAN_DIR/state.json"
+MASTER_JSON="$ORCH_DIR/master.json"
+
+py() {
+  SLUG="$SLUG" PLAN_DIR="$PLAN_DIR" STATE_JSON="$STATE_JSON" \
+    MASTER_JSON="$MASTER_JSON" ORCH_DIR="$ORCH_DIR" \
+    python3 -
+}
+
+cmd_help() {
+  sed -n '2,18p' "$0"
+}
+
+cmd_init() {
+  local count="${ARG3:-5}"
+  mkdir -p "$PLAN_DIR/logs"
+  ITEM_COUNT="$count" py <<'PY'
+import json, os, datetime
+slug = os.environ["SLUG"]
+n = int(os.environ.get("ITEM_COUNT") or 5)
+now = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+items = [
+    {
+        "id": i + 1,
+        "description": f"Fake item {i + 1}",
+        "deps": [i] if i > 0 else [],
+        "status": "queued",
+        "workerPid": None,
+        "tmuxPane": None,
+        "worktree": None,
+        "iteration": 0,
+        "maxIterations": 3,
+        "lastResult": None,
+        "reviewStatus": None,
+    }
+    for i in range(n)
+]
+state = {
+    "version": 1,
+    "plan": slug,
+    "issueNumber": 999,
+    "maxParallelWorkers": 1,
+    "mode": "foreground",
+    "items": items,
+    "finalReview": {"status": "queued", "result": None, "reworkItems": []},
+    "startedAt": now,
+    "updatedAt": now,
+    "status": "running",
+}
+with open(os.environ["STATE_JSON"], "w", encoding="utf-8") as fh:
+    json.dump(state, fh, indent=2)
+
+master_path = os.environ["MASTER_JSON"]
+os.makedirs(os.path.dirname(master_path), exist_ok=True)
+try:
+    with open(master_path, encoding="utf-8") as fh:
+        master = json.load(fh)
+except (FileNotFoundError, json.JSONDecodeError):
+    master = {"version": 1, "plans": []}
+plans = [p for p in master.get("plans", []) if p.get("slug") != slug]
+plans.append({
+    "slug": slug,
+    "status": "running",
+    "statePath": os.path.relpath(os.environ["STATE_JSON"], os.environ["ORCH_DIR"]),
+    "tmuxSession": f"orch-{slug}",
+    "worktree": f"worktrees/{slug}",
+    "startedAt": now,
+    "updatedAt": now,
+    "progress": {"total": n, "done": 0, "running": 0, "failed": 0},
+})
+master["plans"] = plans
+with open(master_path, "w", encoding="utf-8") as fh:
+    json.dump(master, fh, indent=2)
+print(f"init: {slug} with {n} items at {os.environ['PLAN_DIR']}")
+PY
+}
+
+cmd_mutate() {
+  local action="$1"
+  ACTION="$action" py <<'PY'
+import json, os, datetime
+action = os.environ["ACTION"]
+state_path = os.environ["STATE_JSON"]
+master_path = os.environ["MASTER_JSON"]
+slug = os.environ["SLUG"]
+now = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+with open(state_path, encoding="utf-8") as fh:
+    state = json.load(fh)
+items = state["items"]
+
+if action == "tick":
+    running = next((it for it in items if it["status"] == "running"), None)
+    if running is not None:
+        running["status"] = "done"
+        running["lastResult"] = "SHIP"
+        running["reviewStatus"] = "passed"
+        msg = f"tick: item {running['id']} running→done"
+    else:
+        nxt = next((it for it in items if it["status"] == "queued"), None)
+        if nxt is None:
+            msg = "tick: nothing to advance (all done?)"
+        else:
+            nxt["status"] = "running"
+            msg = f"tick: item {nxt['id']} queued→running"
+elif action == "fail":
+    running = next((it for it in items if it["status"] == "running"), None)
+    if running is None:
+        msg = "fail: no running item"
+    else:
+        running["status"] = "failed"
+        running["lastResult"] = "REVISE"
+        msg = f"fail: item {running['id']} running→failed"
+elif action == "ship":
+    for it in items:
+        if it["status"] != "done":
+            it["status"] = "done"
+            it["lastResult"] = "SHIP"
+            it["reviewStatus"] = "passed"
+    state["finalReview"] = {"status": "done", "verdict": "SHIP", "result": "SHIP", "reworkItems": []}
+    state["status"] = "completed"
+    msg = "ship: all items done, finalReview SHIP"
+else:
+    raise SystemExit(f"unknown action {action!r}")
+
+state["updatedAt"] = now
+# Atomic write so the watcher sees a single rename event.
+tmp = state_path + ".tmp"
+with open(tmp, "w", encoding="utf-8") as fh:
+    json.dump(state, fh, indent=2)
+os.replace(tmp, state_path)
+
+with open(master_path, encoding="utf-8") as fh:
+    master = json.load(fh)
+for entry in master.get("plans", []):
+    if entry.get("slug") == slug:
+        total = len(items)
+        done = sum(1 for it in items if it["status"] == "done")
+        running = sum(1 for it in items if it["status"] == "running")
+        failed = sum(1 for it in items if it["status"] == "failed")
+        entry["progress"] = {"total": total, "done": done, "running": running, "failed": failed}
+        entry["updatedAt"] = now
+        if action == "ship":
+            entry["status"] = "completed"
+        break
+mtmp = master_path + ".tmp"
+with open(mtmp, "w", encoding="utf-8") as fh:
+    json.dump(master, fh, indent=2)
+os.replace(mtmp, master_path)
+print(msg)
+PY
+}
+
+cmd_stale() {
+  local age="${ARG3:-600}"
+  AGE="$age" py <<'PY'
+import json, os, datetime
+age = int(os.environ["AGE"])
+slug = os.environ["SLUG"]
+master_path = os.environ["MASTER_JSON"]
+state_path = os.environ["STATE_JSON"]
+old = (datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(seconds=age)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+with open(master_path, encoding="utf-8") as fh:
+    master = json.load(fh)
+for entry in master.get("plans", []):
+    if entry.get("slug") == slug:
+        entry["updatedAt"] = old
+        entry["status"] = "running"
+with open(master_path, "w", encoding="utf-8") as fh:
+    json.dump(master, fh, indent=2)
+
+with open(state_path, encoding="utf-8") as fh:
+    state = json.load(fh)
+state["updatedAt"] = old
+with open(state_path, "w", encoding="utf-8") as fh:
+    json.dump(state, fh, indent=2)
+print(f"stale: rewound updatedAt to {old} ({age}s ago)")
+PY
+}
+
+cmd_remove() {
+  py <<'PY'
+import json, os, shutil
+slug = os.environ["SLUG"]
+plan_dir = os.environ["PLAN_DIR"]
+master_path = os.environ["MASTER_JSON"]
+if os.path.isdir(plan_dir):
+    shutil.rmtree(plan_dir)
+try:
+    with open(master_path, encoding="utf-8") as fh:
+        master = json.load(fh)
+    before = len(master.get("plans", []))
+    master["plans"] = [p for p in master.get("plans", []) if p.get("slug") != slug]
+    with open(master_path, "w", encoding="utf-8") as fh:
+        json.dump(master, fh, indent=2)
+    removed = before - len(master["plans"])
+except FileNotFoundError:
+    removed = 0
+print(f"remove: deleted plan dir + {removed} master.json entry/entries")
+PY
+}
+
+case "$CMD" in
+  init) cmd_init ;;
+  tick) cmd_mutate tick ;;
+  fail) cmd_mutate fail ;;
+  ship) cmd_mutate ship ;;
+  stale) cmd_stale ;;
+  remove) cmd_remove ;;
+  help | -h | --help) cmd_help ;;
+  *)
+    echo "unknown command: $CMD" >&2
+    cmd_help
+    exit 1
+    ;;
+esac

--- a/tools/verify-tui.py
+++ b/tools/verify-tui.py
@@ -644,13 +644,14 @@ def verify_outreach(verbose: bool = False) -> bool:
 
 
 def verify_plan_execution(verbose: bool = False) -> bool:
-    """Verify ProjectStatePane auto-opens a plan tab from master.json.
+    """Verify ProjectStatePane auto-opens a plan tab on in-session arrival.
 
-    Writes a fixture project containing ``.orchestrator/master.json`` plus
-    one plan dir, mounts ``ProjectStatePane``, registers a stub model
-    factory, and asserts the pane reveals itself, the plan tab is
-    mounted under the expected id, and the status rail renders one glyph
-    per plan item with the correct running glyph.
+    The pane uses a baseline filter: pre-existing plans (those in
+    ``master.json`` at canon launch) are NOT auto-opened. This smoke
+    starts with an empty plan list, mounts the pane, then writes a new
+    plan to ``master.json`` — simulating an orch run started while
+    canon is up. The new slug must auto-open, reveal the pane, and
+    render its tab + status rail.
     """
     import json
     import tempfile
@@ -704,7 +705,12 @@ def verify_plan_execution(verbose: bool = False) -> bool:
             json.dumps(_state_payload(status)), encoding="utf-8"
         )
 
-    def _write_fixture(project: Path) -> None:
+    def _write_empty_master(project: Path) -> None:
+        master = project / ".orchestrator" / "master.json"
+        master.parent.mkdir(parents=True)
+        master.write_text(json.dumps({"plans": []}), encoding="utf-8")
+
+    def _add_plan_in_session(project: Path) -> None:
         plans_dir = project / ".orchestrator" / "plans" / SLUG
         (plans_dir / "logs").mkdir(parents=True)
         _write_state(plans_dir, "running")
@@ -735,7 +741,7 @@ def verify_plan_execution(verbose: bool = False) -> bool:
     async def _run() -> None:
         with tempfile.TemporaryDirectory() as tmp:
             project = Path(tmp)
-            _write_fixture(project)
+            _write_empty_master(project)
             plans_dir = project / ".orchestrator" / "plans" / SLUG
 
             class Harness(App[None]):
@@ -759,6 +765,10 @@ def verify_plan_execution(verbose: bool = False) -> bool:
                     return model
 
                 pane.configure_plan_execution(_factory)
+                await pilot.pause()
+                # Simulate an orch run starting while canon is already up.
+                _add_plan_in_session(project)
+                await pilot.pause()
                 await pilot.pause()
                 await pilot.pause()
 


### PR DESCRIPTION
## Summary

The plan-execution factory builds each `PlanExecutionModel` with `target=ProjectStatePane`. When `_scan_state` detects a `state.json` diff and posts `ItemStatusChanged` / `PlanFinished`, the message lands on the pane — which has no handler — and bubbles upward. The tab is a descendant of the pane, so it never receives the message. Result: the rail reflects the snapshot taken at tab-mount and never updates, even though the directory watcher and 2.5s backstop fire correctly.

`PlanExecutionModel` now exposes `set_target()`. `PlanExecutionSection.open_tab` swaps the model's sink to the freshly-mounted tab right after construction, so the existing `on_plan_execution_tab_*` handlers fire.

Also bundles a small dev harness, `tools/fake-plan.sh`, which drives a fake plan from the shell (`init`/`tick`/`fail`/`ship`/`stale`/`remove`) so the canon view can be exercised without spawning real workers. This also surfaced the bug — previous tests bypassed the production wiring with a `_LateTarget` proxy pointed directly at the tab.

Includes the prior `canon: stale-plan detection, baseline filter for plan auto-open, panel routes` commit (`1da2bfc`) which had not yet been pushed.

## Verification

End-to-end in tmux against `claude-code-config`:

| step | rail |
|---|---|
| `fake-plan.sh init` (4 queued) | `○ ○ ○ ○ running` |
| `fake-plan.sh tick` × 2 | `✓ ○ ○ ○ running` |
| `fake-plan.sh ship` | `✓ ✓ ✓ ✓ SHIP` |

## Test plan

- [ ] `uv run pytest -q tests/data/test_plan_execution_model.py tests/widgets/test_plan_execution_tab.py`
- [ ] `uv run python tools/verify-tui.py`
- [ ] Manual: `tools/fake-plan.sh init` in a project where `canon .` is open; ticks should flip the rail glyphs within ~3s.

## Known follow-ups (not in this PR)

- Model reads `finalReview.verdict` but real orch state.json writes `finalReview.result` — `PlanFinished` never fires for real plans, so the verdict label stays "running". Trivial fix in `_extract_verdict`.
- Master.json entries occasionally stuck on `status: "running"` after orch exits cleanly — orch-side, not canon. Stale-detection (90s threshold) compensates on the running-plans list.
- `tests/widgets/test_plan_execution_section.py` has 5 pre-existing failures: `_StubModel` lacks `plan_dir` after the protocol bump in PR #38.

🤖 Generated with [Claude Code](https://claude.com/claude-code)