### PR TITLE
Plan execution panel: terminal banner, progress gauge, close + PR controls

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -57,8 +57,20 @@ canon-ctl        # Manage Canon TUI configuration
 
 ## Updating
 
-Run `/apply-canon-tui` from any directory, or:
+Once canon is installed, the easiest path is the built-in command:
 
 ```bash
+canon update              # pull + reinstall from main
+canon update --check      # show local vs remote version, no install
+canon update --branch develop  # install from a different branch / tag
+```
+
+Equivalent manual paths if you'd rather not use the subcommand:
+
+```bash
+# Slash command (works from any directory in your AI agent harness):
+/apply-canon-tui
+
+# Raw uv invocation:
 uv tool install "canon-tui @ git+https://github.com/DEGAorg/canon-tui.git@main" --force --reinstall
 ```

--- a/docs/dev-state-schema.md
+++ b/docs/dev-state-schema.md
@@ -1,0 +1,111 @@
+# State.json Contract — Canon TUI ↔ Orchestrator Engine
+
+The plan-execution panel renders entirely from local files written by the
+orchestrator engine in `claude-code-config`. The TUI does **not** call
+GitHub. This doc pins the fields the TUI reads and where they get
+written, so cross-repo schema drift is easy to spot.
+
+## Source files
+
+Per plan, under `.orchestrator/plans/<slug>/`:
+
+| File | Reader | Writer |
+|------|--------|--------|
+| `state.json` | `src/toad/data/plan_execution_model.py` | `claude-code-config/scripts/orch-engine.sh`, `orch-review.sh`, `orch-verify.sh`, `orch-watchdog.sh` |
+| `logs/<id>.log` | `PlanExecutionModel._scan_logs` | worker shells |
+
+Plus `master.json` at the orchestrator root, read by
+`src/toad/widgets/orchestrator_state.py`.
+
+## Fields the TUI consumes
+
+```jsonc
+{
+  "plan": "20260428-stop-hook-agent-bump",      // slug
+  "issueNumber": 258,
+  "status": "running"                            // running | verifying | completed | failed | aborted
+                                                 // — terminal trigger #1
+  "startedAt": "2026-04-28T20:14:03Z",
+  "updatedAt": "2026-04-28T20:30:21Z",           // elapsed = updated - started
+
+  "items": [
+    { "id": 1, "description": "...",
+      "deps": [], "status": "done" }             // queued | ready | running | done | failed | review
+  ],
+
+  "finalReview": {
+    "status": "done",                            // pending | running | done
+    "result": "SHIP",                            // SHIP | REVISE — terminal trigger #2
+    "reworkItems": [],                           // ints; len() = items_reworked
+    "prUrl": null,                               // ★ engine TODO — see "Open gaps" below
+    "prNumber": null                             // ★ engine TODO
+  },
+
+  "verification": {
+    "status": "passed",                          // passed | failed | (absent if not run)
+    "unchecked": []                              // list or int — both accepted
+  },
+
+  "reviewIterations": 7                          // optional — engine TODO, used in summary line
+}
+```
+
+The TUI tolerates absent fields; presence drives the completion banner.
+
+## Terminal-state detection
+
+`PlanExecutionModel._is_terminal()` in
+`src/toad/data/plan_execution_model.py` fires `PlanFinished` when **any**
+of these are true:
+
+- `state.status` ∈ `{completed, failed, aborted}`
+- `state.finalReview.result` ∈ `{SHIP, REVISE}`
+
+Both paths matter — engine bailouts (budget exhausted, watchdog kill)
+reach `status: failed` without ever populating `finalReview.result`,
+and we want the panel to flip terminal anyway.
+
+## Open gaps (engine side)
+
+The engine has the data; it just doesn't persist it. Each gap below
+degrades the completion banner gracefully — TUI handles missing fields
+without crashing — but the banner is more useful when they're present.
+
+### 1. `finalReview.prUrl` / `finalReview.prNumber` ★
+
+`scripts/orch-engine.sh` already has `PR_URL` in scope at the
+`gh-push-and-pr.sh` invocation (~line 875). The success branch logs it
+but never writes it to state. Fix: in the `if [[ "${rc}" -eq 0 ]]` block,
+patch `state.json` with
+`.finalReview.prUrl = $url | .finalReview.prNumber = $num` before the
+`status: "completed"` write at ~line 917. Spec:
+`claude-code-config/docs/specs/canon-tui-plan-completion.md`,
+"Engine-side requirement".
+
+### 2. `reviewIterations` (top-level int)
+
+Used to render `Reviews: N total iterations` on the summary line. Nice
+to have. Increment in `scripts/orch-review.sh` whenever a review pass
+runs.
+
+## When changing the schema
+
+If you add or rename a field on the engine side, update **both**:
+
+1. `_initial_parse` / `_scan_state` / `_build_terminal_info` in
+   `src/toad/data/plan_execution_model.py`.
+2. The header / terminal-line render in
+   `src/toad/widgets/plan_execution_tab.py::_format_terminal_line`.
+
+Tests fixtures live in `tests/data/test_plan_execution_model.py` and
+`tests/widgets/test_plan_execution_tab.py` — keep the fixture payload
+matching the real engine schema (e.g. `finalReview.result`, not
+`.verdict`). Drift here is silent: a wrong field name returns `None`,
+the panel never reaches terminal, and no test fails.
+
+## History note
+
+A previous version of the model read `finalReview.verdict` — a phantom
+field that never existed in any engine version. The terminal banner
+silently never fired. See commit `52a6528` ("Plan completion: terminal
+state, phase header, progress gauge") for the fix.

--- a/docs/dev-textual-quirks.md
+++ b/docs/dev-textual-quirks.md
@@ -1,0 +1,92 @@
+# Textual Quirks & Local Patches
+
+Things upstream Textual gets subtly wrong that we work around in
+Canon. Each entry says **what's wrong**, **why our fix exists**, and
+**how to remove the workaround** if upstream eventually fixes it.
+
+## 1. `alt+<multichar-key>` is dropped on legacy xterm input
+
+**Symptom.** `option+enter` in macOS Terminal.app and iTerm2 (default
+config, no Kitty keyboard protocol) arrives as a plain `enter` event.
+Widgets cannot tell it apart from Return, so option+enter ends up
+sending the prompt instead of inserting a newline.
+
+**Cause.** `textual._xterm_parser.XTermParser._sequence_to_key_events`
+only prepends `alt+` to **single-character** key names:
+
+```python
+# textual/_xterm_parser.py, around line 394
+if len(name) == 1 and alt:
+    name = f"alt+{name}"
+```
+
+When iTerm2 sends `ESC + CR` for option+enter, the parser correctly
+flags `alt=True` but skips the prefix because `name == "enter"` is
+5 chars. The Key event arrives with `key="enter"`, alt info lost. Same
+problem for any multi-char key: `tab`, `space`, `home`, etc.
+
+**Workaround.** `src/toad/_textual_key_patch.py` wraps
+`_sequence_to_key_events` and re-emits the event with the `alt+` prefix
+when `alt=True` was passed but the key string came back without a
+modifier prefix. The patch is loaded eagerly from `src/toad/__init__.py`
+so it applies before the driver starts reading keys. Idempotent.
+
+**Removal criteria.** If a future Textual release removes the
+`len(name) == 1` gate (e.g. by always prepending modifiers when the
+parser detected them), drop `_textual_key_patch.py` and the import in
+`__init__.py`. Smoke-test by pressing option+enter on a stock macOS
+Terminal — it should arrive as `alt+enter` without the patch.
+
+**Also affects.** Anywhere we want to bind `alt+<word>`. If a binding
+seems silently dead after upgrading Textual, this is the first thing to
+check.
+
+## 2. Two bindings on the same chord don't fall through
+
+**Symptom.** In an earlier version of `prompt.py` we had two bindings
+on `shift+enter` — one for `newline`, one for `multiline_submit` —
+gated by `check_action`. Once `multi_line` flipped to True, **both**
+keys went dead: enter ran the now-disabled `submit`, shift+enter ran
+the now-disabled `newline`, and the second binding for the same chord
+was never tried.
+
+**Cause.** Textual stops at the first binding match for a key; if
+`check_action` returns False, the key is consumed but no action runs.
+There is no fall-through to the next binding for the same chord.
+
+**Workaround.** Don't share chords. Use one binding per chord and
+branch inside the action. See `src/toad/widgets/prompt.py`:
+`action_enter_pressed` / `action_shift_enter_pressed`.
+
+**Note.** This is a Textual design choice, not a bug. Don't try to
+"fix" it — just write your bindings to avoid the pattern.
+
+## 3. Circles render badly in terminals
+
+**Symptom.** Terminal cells are roughly 2:1 (height:width); any
+attempt at a "donut" or "pie" chart drawn from cell positions looks
+oblong, lopsided, or chunky depending on font and zoom.
+
+**Workaround.** Don't draw circles. The plan-execution header uses a
+flat 2-row gauge (`PlanDonut` widget — name kept for import stability
+even though the visual is now horizontal): segmented bar above,
+percentage below. Reads cleanly at any size.
+
+**Lesson for new widgets.** Prefer rectangular composition (bars,
+sparklines, stacked blocks) over rotational shapes. Half-block
+characters (`▀ ▄ ▌ ▐`) give 2× vertical resolution if you need finer
+detail.
+
+## 4. `Static` with Rich `Text` doesn't auto-expand
+
+This one is in the project CLAUDE.md but worth repeating because it
+keeps biting:
+
+> `Static` with Rich Text does not auto-expand width — set
+> `styles.min_width` explicitly to enable horizontal scroll.
+> `ScrollableContainer` handles both axes; don't nest
+> `VerticalScroll` inside `HorizontalScroll`.
+> `height: auto` on a scroll container collapses it — use `height: 1fr`.
+
+If a widget mysteriously renders truncated or won't scroll, check sizing
+before anything else.

--- a/docs/handoff-core-builder-logs.md
+++ b/docs/handoff-core-builder-logs.md
@@ -1,0 +1,96 @@
+# Hand-off to `claude-code-config` — Builder/Run log content
+
+The Canon TUI's **State view → Builder log** renders whatever the
+running strategy template writes into `.canon/state.json`. The log
+text and the metric keys/values surface in the user-facing panel
+verbatim. Two things in there are jargon-y or unclear and should be
+fixed in the engine / strategy bundle, not the TUI.
+
+## Where this is read in canon-tui
+
+For reference only — no changes needed on the TUI side:
+
+| File | Role |
+|------|------|
+| `src/toad/widgets/canon_state.py` | Parses `.canon/state.json` into `CanonState(logs, metrics, …)` |
+| `src/toad/widgets/builder_view.py` | Renders status bar, logs, metrics |
+
+## What to fix in core / strategy templates
+
+### 1. Replace "Cycle N — …" log wording
+
+Today's State log includes lines like:
+
+```
+Cycle 2 — fetching NBA futures...
+```
+
+"Cycle" reads as engineer jargon to anyone who isn't in the loop. The
+strategy template that emits these lines should use a more concrete
+verb that matches what it just did. Suggested replacements:
+
+| Old | New |
+|-----|-----|
+| `Cycle 1 — fetching NBA futures...` | `Round 1: refreshing odds for NBA futures…` |
+| `Cycle 2 — fetching NBA futures...` | `Round 2: refreshing odds for NBA futures…` |
+| `Cycle N — <action>...` | `Round N: <action>…` |
+
+If "round" doesn't fit, alternatives that read naturally:
+- `Sweep N: …`
+- `Pass N: …`
+- `Pull N: …` (when the action is a fetch)
+
+The literal verb depends on what the cycle does — fetching odds is a
+"refresh", running a model pass is a "evaluation", placing trades is a
+"trade pass". Pick the verb at the strategy level so each line tells
+the user what was *done*, not which iteration counter ticked.
+
+### 2. Rename the metric keys
+
+Today's State view bottom row:
+
+```
+mode: dry-run        cycles: 0
+signals: 18          errors: 0
+games: 0             markets: 0
+```
+
+`cycles` and `signals` are template-internal terminology. From a
+user's perspective those keys should describe outcomes:
+
+| Current key | Suggested key | Why |
+|-------------|---------------|-----|
+| `cycles`  | `passes` or `runs` | "How many times did the strategy run?" |
+| `signals` | `opportunities` or `signals_found` | What does a signal *mean* to the user? |
+| `games`   | `games_tracked` or `games` (keep) | Already clear if the audience knows the domain |
+| `markets` | `markets_checked` | Verb makes the count's meaning explicit |
+| `errors`  | `errors` (keep) | Already clear |
+| `mode`    | `mode` (keep) | Already clear |
+
+Keys are written to `state.metrics` as a flat dict by the strategy
+runner. Renaming is a one-line change wherever the metric is bumped
+(e.g. `state.metrics.cycles += 1` → `state.metrics.passes += 1`).
+
+If you want units alongside numbers — e.g. show
+`signals_found: 18 today` instead of `signals: 18` — encode the unit
+in the key (`signals_found_today`) or post a string value
+(`metrics.signals = "18 (last 1h)"`). The TUI renders strings as-is.
+
+### 3. Optional: log levels
+
+Today entries are coloured by `level` (`info` / `warn` / `error` /
+`debug`). The level text itself is **not** displayed — only the colour
+varies. If you want explicit `WARN` / `ERROR` tags in the line, that
+would be a TUI change (in `_render_log`). Mention it if so.
+
+## Summary checklist for core
+
+- [ ] Strategy templates replace "Cycle N — <verb>…" log wording
+      with action-led phrasing (Round / Pass / Sweep / Pull / etc.).
+- [ ] `state.metrics` keys renamed (`cycles`, `signals`, `markets` at
+      minimum) to user-facing nouns.
+- [ ] Decide whether log levels should appear inline as text tags;
+      if yes, file a follow-up on canon-tui.
+
+After these land, the State view in canon-tui will reflect them
+automatically — no canon-tui changes required.

--- a/docs/handoff-core-builder-logs.md
+++ b/docs/handoff-core-builder-logs.md
@@ -1,23 +1,24 @@
-# Hand-off to `claude-code-config` — Builder/Run log content
+# Hand-off to `claude-code-config` — Builder/Run log wording
 
 The Canon TUI's **State view → Builder log** renders whatever the
 running strategy template writes into `.canon/state.json`. The log
-text and the metric keys/values surface in the user-facing panel
-verbatim. Two things in there are jargon-y or unclear and should be
-fixed in the engine / strategy bundle, not the TUI.
+text surfaces in the user-facing panel verbatim. One thing in there
+reads as engineer jargon and should be fixed in the engine /
+strategy bundle, not the TUI.
 
-## Where this is read in canon-tui
-
-For reference only — no changes needed on the TUI side:
+## Where this is read in canon-tui (reference only)
 
 | File | Role |
 |------|------|
 | `src/toad/widgets/canon_state.py` | Parses `.canon/state.json` into `CanonState(logs, metrics, …)` |
-| `src/toad/widgets/builder_view.py` | Renders status bar, logs, metrics |
+| `src/toad/widgets/builder_view.py` | Renders status bar, metrics, logs |
 
-## What to fix in core / strategy templates
+No canon-tui changes needed for this hand-off — only the strings in
+the log lines.
 
-### 1. Replace "Cycle N — …" log wording
+## What to fix
+
+### Replace "Cycle N — …" log wording
 
 Today's State log includes lines like:
 
@@ -26,8 +27,8 @@ Cycle 2 — fetching NBA futures...
 ```
 
 "Cycle" reads as engineer jargon to anyone who isn't in the loop. The
-strategy template that emits these lines should use a more concrete
-verb that matches what it just did. Suggested replacements:
+strategy template that emits these lines should use a verb that
+matches what the cycle actually did. Suggested replacements:
 
 | Old | New |
 |-----|-----|
@@ -36,63 +37,37 @@ verb that matches what it just did. Suggested replacements:
 | `Cycle N — <action>...` | `Round N: <action>…` |
 
 If "round" doesn't fit, alternatives that read naturally:
+
 - `Sweep N: …`
 - `Pass N: …`
 - `Pull N: …` (when the action is a fetch)
 
 The literal verb depends on what the cycle does — fetching odds is a
-"refresh", running a model pass is a "evaluation", placing trades is a
-"trade pass". Pick the verb at the strategy level so each line tells
-the user what was *done*, not which iteration counter ticked.
+"refresh", running a model pass is an "evaluation", placing trades is
+a "trade pass". Pick the verb at the strategy level so each line
+tells the user what was *done*, not which iteration counter ticked.
 
-### 2. Rename the metric keys
+## What does NOT need a core change
 
-Today's State view bottom row:
+- **Metric labels (Runs, Opportunities, Games, Markets, Errors,
+  Mode).** The TUI now applies these names at render time via an
+  alias map in `src/toad/widgets/builder_view.py::METRIC_LABEL_ALIASES`
+  (canon-tui ≥ 0.7.10). Core can keep writing `cycles` / `signals`
+  in `state.metrics` — the panel reads clean either way.
 
-```
-mode: dry-run        cycles: 0
-signals: 18          errors: 0
-games: 0             markets: 0
-```
+  Optional polish: if you do rename the keys in `state.metrics` for
+  consistency on the engine side, drop the matching entries from
+  `METRIC_LABEL_ALIASES` afterwards. Not blocking.
 
-`cycles` and `signals` are template-internal terminology. Agreed
-user-facing names — natural language, no underscores:
-
-| Current key | New key       |
-|-------------|---------------|
-| `cycles`    | `runs`        |
-| `signals`   | `opportunities` |
-| `games`     | `games` (keep) |
-| `markets`   | `markets` (keep) |
-| `errors`    | `errors` (keep) |
-| `mode`      | `mode` (keep) |
-
-Keys are written to `state.metrics` as a flat dict by the strategy
-runner. Renaming is a one-line change wherever the metric is bumped
-(e.g. `state.metrics.cycles += 1` → `state.metrics.runs += 1`).
-
-**TUI-side stopgap already shipped (canon-tui ≥ 0.7.10).** Until core
-lands, the TUI renders the labels via an alias map in
-`src/toad/widgets/builder_view.py::METRIC_LABEL_ALIASES`. So the
-panel reads "Runs / Opportunities / Games / Markets / Errors / Mode"
-even if `state.metrics` still uses the old keys. Once core renames
-the keys, drop the obsolete entries from the alias map.
-
-### 3. Optional: log levels
-
-Today entries are coloured by `level` (`info` / `warn` / `error` /
-`debug`). The level text itself is **not** displayed — only the colour
-varies. If you want explicit `WARN` / `ERROR` tags in the line, that
-would be a TUI change (in `_render_log`). Mention it if so.
+- **Log levels.** The TUI colours each log line by `level` (`info` /
+  `warn` / `error` / `debug`); no core change needed. If you ever
+  want explicit `[ERROR]` / `[WARN]` text tags inline, that's a TUI
+  change — file an issue on canon-tui.
 
 ## Summary checklist for core
 
-- [ ] Strategy templates replace "Cycle N — <verb>…" log wording
+- [ ] Strategy templates replace `Cycle N — <verb>…` log wording
       with action-led phrasing (Round / Pass / Sweep / Pull / etc.).
-- [ ] `state.metrics` keys renamed (`cycles`, `signals`, `markets` at
-      minimum) to user-facing nouns.
-- [ ] Decide whether log levels should appear inline as text tags;
-      if yes, file a follow-up on canon-tui.
 
-After these land, the State view in canon-tui will reflect them
-automatically — no canon-tui changes required.
+That's it. After this lands, the State view in canon-tui reflects it
+automatically.

--- a/docs/handoff-core-builder-logs.md
+++ b/docs/handoff-core-builder-logs.md
@@ -55,26 +55,28 @@ signals: 18          errors: 0
 games: 0             markets: 0
 ```
 
-`cycles` and `signals` are template-internal terminology. From a
-user's perspective those keys should describe outcomes:
+`cycles` and `signals` are template-internal terminology. Agreed
+user-facing names — natural language, no underscores:
 
-| Current key | Suggested key | Why |
-|-------------|---------------|-----|
-| `cycles`  | `passes` or `runs` | "How many times did the strategy run?" |
-| `signals` | `opportunities` or `signals_found` | What does a signal *mean* to the user? |
-| `games`   | `games_tracked` or `games` (keep) | Already clear if the audience knows the domain |
-| `markets` | `markets_checked` | Verb makes the count's meaning explicit |
-| `errors`  | `errors` (keep) | Already clear |
-| `mode`    | `mode` (keep) | Already clear |
+| Current key | New key       |
+|-------------|---------------|
+| `cycles`    | `runs`        |
+| `signals`   | `opportunities` |
+| `games`     | `games` (keep) |
+| `markets`   | `markets` (keep) |
+| `errors`    | `errors` (keep) |
+| `mode`      | `mode` (keep) |
 
 Keys are written to `state.metrics` as a flat dict by the strategy
 runner. Renaming is a one-line change wherever the metric is bumped
-(e.g. `state.metrics.cycles += 1` → `state.metrics.passes += 1`).
+(e.g. `state.metrics.cycles += 1` → `state.metrics.runs += 1`).
 
-If you want units alongside numbers — e.g. show
-`signals_found: 18 today` instead of `signals: 18` — encode the unit
-in the key (`signals_found_today`) or post a string value
-(`metrics.signals = "18 (last 1h)"`). The TUI renders strings as-is.
+**TUI-side stopgap already shipped (canon-tui ≥ 0.7.10).** Until core
+lands, the TUI renders the labels via an alias map in
+`src/toad/widgets/builder_view.py::METRIC_LABEL_ALIASES`. So the
+panel reads "Runs / Opportunities / Games / Markets / Errors / Mode"
+even if `state.metrics` still uses the old keys. Once core renames
+the keys, drop the obsolete entries from the alias map.
 
 ### 3. Optional: log levels
 

--- a/docs/plan-tab-followups.md
+++ b/docs/plan-tab-followups.md
@@ -1,0 +1,71 @@
+# Plan Execution Tab — Follow-ups & Open Questions
+
+Notes captured during the 0.7.5/0.7.6 cleanup pass so they don't get lost
+in chat. Review when convenient.
+
+## Decisions made
+
+- Verification line is **hidden entirely** in the terminal banner.
+  Engine treats verify as advisory (`SHIP` proceeds even when verify
+  flags unchecked criteria), so showing `verify: failed` next to
+  `✓ Completed (SHIP)` reads as a contradiction. We may surface it
+  differently later (see open questions).
+- PR is now reachable through a `→ PR` button in the header (opens
+  `terminal.pr_url` via `webbrowser.open`). PR # still inline in the
+  title so the run identity stays scannable.
+- Close button (`✕`) lives in the header row. Emits
+  `PlanExecutionTab.CloseRequested(slug)`; the section handles it via
+  the existing `close_tab(slug)` path.
+- Bottom `PlanStatusRail` removed from this tab. The widget still
+  exists for any other consumer.
+
+## Open questions for review
+
+### 1. Should advisory verification be visible at all?
+
+Right now it's invisible. Two reasonable alternatives if you want it
+back without the contradiction:
+
+- **Quiet badge.** Add `⚠` token after the completed badge: `✓ Completed
+  (SHIP) ⚠`. Hover/tooltip explains advisory verify.
+- **Detail line on demand.** A small `verify ⓘ` button that expands
+  to show the unchecked criteria when clicked.
+
+Decision needed before re-enabling.
+
+### 2. PR button: open in browser vs. switch to in-TUI PR view?
+
+Today the button uses `webbrowser.open(pr_url)`. The TUI also has a PR
+view at *Planning > tab-tasks* with a `type=pr` filter chip
+(`PANEL_ROUTES["prs"]` in `project_state_pane.py`). We could route
+there instead — but it lists *all* PRs, not just this run's. Best path
+is probably both: primary action = browser; secondary = "show in PR
+list" with a filter.
+
+### 3. Close button visibility while a plan is still running
+
+Should `✕` close a *running* plan tab? Right now it always closes —
+the orchestrator process is detached (tmux), so closing the tab does
+not stop the run. May need a confirm dialog if the run is still live.
+Easy follow-up.
+
+### 4. Donut name vs. shape
+
+The widget is `PlanDonut` but renders a flat 2-row gauge. Kept the
+name to avoid churn on imports. Worth renaming in a sweep when
+nothing else is in flight.
+
+### 5. Pre-existing test failures on develop
+
+Five tests in `tests/widgets/test_plan_execution_section.py` plus
+sixteen in `tests/test_gantt_timeline.py` and a handful in
+`tests/test_canon_sections.py` fail on `develop` independent of any
+recent work — `_StubModel` doesn't satisfy the
+`PlanExecutionModel` protocol (missing `plan_dir`), and the gantt
+fixtures look stale. Not blocking, but worth a clean-up pass.
+
+## Abstract / placeholder implementations
+
+None in this pass — every change is concrete. The PR-button → browser
+behaviour is the simplest viable wiring; replace it when the in-TUI
+PR view filter route is wired (see open question #2).

--- a/docs/plan-tab-followups.md
+++ b/docs/plan-tab-followups.md
@@ -33,6 +33,8 @@ back without the contradiction:
 
 Decision needed before re-enabling.
 
+- not visible now
+
 ### 2. PR button: open in browser vs. switch to in-TUI PR view?
 
 Today the button uses `webbrowser.open(pr_url)`. The TUI also has a PR
@@ -42,6 +44,8 @@ there instead — but it lists *all* PRs, not just this run's. Best path
 is probably both: primary action = browser; secondary = "show in PR
 list" with a filter.
 
+-  we should route to the tui pr view in state view. something clean. nice and local, dry, reuse, not awkward.
+
 ### 3. Close button visibility while a plan is still running
 
 Should `✕` close a *running* plan tab? Right now it always closes —
@@ -49,20 +53,30 @@ the orchestrator process is detached (tmux), so closing the tab does
 not stop the run. May need a confirm dialog if the run is still live.
 Easy follow-up.
 
+- yeah we can add a confirmation, stating the process will continue you are just closing the view. could we reopen if we request it to the agent?
+
 ### 4. Donut name vs. shape
 
 The widget is `PlanDonut` but renders a flat 2-row gauge. Kept the
 name to avoid churn on imports. Worth renaming in a sweep when
 nothing else is in flight.
 
+- rename it to progress bar or something more appropiare
+
 ### 5. Pre-existing test failures on develop
 
-Five tests in `tests/widgets/test_plan_execution_section.py` plus
-sixteen in `tests/test_gantt_timeline.py` and a handful in
-`tests/test_canon_sections.py` fail on `develop` independent of any
-recent work — `_StubModel` doesn't satisfy the
-`PlanExecutionModel` protocol (missing `plan_dir`), and the gantt
-fixtures look stale. Not blocking, but worth a clean-up pass.
+- ✅ **`test_plan_execution_section.py` (5 tests).** Fixed in this PR
+  by extending `_StubModel` to satisfy the full `PlanExecutionModel`
+  protocol (`plan_dir`, `poll_now`, `set_target`).
+- ⏭ **`test_gantt_timeline.py` (16 tests).** The render functions
+  changed signature — `render_bar_row` / `render_group_header` /
+  `render_gantt` now return single `Text` objects, not
+  `(label, track)` tuples — but the tests still unpack tuples. Needs
+  a wholesale rewrite. Deferred to its own PR; not blocking.
+- ⏭ **`test_canon_sections.py` (7 tests).** Tests assert that
+  `_render_log` emits the level token (`INFO`, `WARN`, …) inline,
+  but the current implementation only varies colour. Either
+  reintroduce the token or rewrite the assertions. Deferred.
 
 ## Abstract / placeholder implementations
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canon-tui"
-version = "0.7.14"
+version = "0.7.15"
 description = "Canon TUI — a unified experience for AI in your terminal."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canon-tui"
-version = "0.7.11"
+version = "0.7.12"
 description = "Canon TUI — a unified experience for AI in your terminal."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canon-tui"
-version = "0.7.12"
+version = "0.7.13"
 description = "Canon TUI — a unified experience for AI in your terminal."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canon-tui"
-version = "0.7.8"
+version = "0.7.9"
 description = "Canon TUI — a unified experience for AI in your terminal."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canon-tui"
-version = "0.7.2"
+version = "0.7.3"
 description = "Canon TUI — a unified experience for AI in your terminal."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canon-tui"
-version = "0.7.13"
+version = "0.7.14"
 description = "Canon TUI — a unified experience for AI in your terminal."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canon-tui"
-version = "0.7.10"
+version = "0.7.11"
 description = "Canon TUI — a unified experience for AI in your terminal."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canon-tui"
-version = "0.7.6"
+version = "0.7.7"
 description = "Canon TUI — a unified experience for AI in your terminal."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canon-tui"
-version = "0.7.9"
+version = "0.7.10"
 description = "Canon TUI — a unified experience for AI in your terminal."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canon-tui"
-version = "0.7.1"
+version = "0.7.2"
 description = "Canon TUI — a unified experience for AI in your terminal."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canon-tui"
-version = "0.7.7"
+version = "0.7.8"
 description = "Canon TUI — a unified experience for AI in your terminal."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canon-tui"
-version = "0.7.5"
+version = "0.7.6"
 description = "Canon TUI — a unified experience for AI in your terminal."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canon-tui"
-version = "0.7.3"
+version = "0.7.5"
 description = "Canon TUI — a unified experience for AI in your terminal."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/src/toad/__init__.py
+++ b/src/toad/__init__.py
@@ -1,6 +1,10 @@
 from typing import Literal, Mapping
 import platform
 
+from toad._textual_key_patch import apply as _apply_textual_key_patch
+
+_apply_textual_key_patch()
+
 NAME = "canon"
 TITLE = "Canon"
 

--- a/src/toad/_textual_key_patch.py
+++ b/src/toad/_textual_key_patch.py
@@ -1,0 +1,46 @@
+"""Make Textual surface ``alt+<multichar-key>`` events on legacy xterm input.
+
+Textual's xterm parser only prepends the ``alt+`` modifier to **single
+character** key names (see ``_xterm_parser.py``: ``if len(name) == 1 and
+alt:``). On terminals that don't speak the Kitty keyboard protocol —
+which still includes most stock macOS Terminal.app and iTerm2 setups
+even with "Use Option as Meta" / "Esc+" enabled — pressing
+``option+enter`` arrives as the byte sequence ``ESC + CR``. The parser
+correctly detects ``alt=True`` but skips the ``alt+`` prefix because the
+key name is ``"enter"`` (5 chars), so widgets receive a plain ``enter``
+event with no way to tell it apart from a regular Return.
+
+We patch ``XTermParser._sequence_to_key_events`` to wrap its output and
+re-emit a properly-prefixed event whenever ``alt`` was set but the
+resulting key string lacks the modifier. The patch is import-time and
+idempotent — calling it twice is a no-op. It is loaded from
+``toad/__init__.py`` so every Canon entry point picks it up before the
+app driver starts reading keys.
+"""
+
+from __future__ import annotations
+
+from textual import events
+from textual._xterm_parser import XTermParser
+
+
+_PATCH_FLAG = "_canon_alt_key_patch_applied"
+_KNOWN_MODIFIERS = ("alt+", "shift+", "ctrl+", "meta+", "super+", "hyper+")
+
+
+def apply() -> None:
+    """Install the alt-prefix backfill. Safe to call multiple times."""
+    if getattr(XTermParser, _PATCH_FLAG, False):
+        return
+
+    original = XTermParser._sequence_to_key_events
+
+    def patched(self, sequence: str, alt: bool = False):  # type: ignore[no-untyped-def]
+        for event in original(self, sequence, alt):
+            if alt and event.key and not event.key.startswith(_KNOWN_MODIFIERS):
+                yield events.Key(f"alt+{event.key}", event.character)
+            else:
+                yield event
+
+    XTermParser._sequence_to_key_events = patched  # type: ignore[method-assign]
+    setattr(XTermParser, _PATCH_FLAG, True)

--- a/src/toad/cli.py
+++ b/src/toad/cli.py
@@ -347,5 +347,104 @@ def about() -> None:
     print(about.render(app))
 
 
+_CANON_GIT_URL = "git+https://github.com/DEGAorg/canon-tui.git"
+
+
+@main.command("update")
+@click.option(
+    "--branch",
+    default="main",
+    show_default=True,
+    help="Branch (or tag) to install from the canon-tui repo.",
+)
+@click.option(
+    "--check",
+    is_flag=True,
+    help="Print local + remote versions without installing.",
+)
+def update(branch: str, check: bool) -> None:
+    """Update canon to the latest published build from GitHub."""
+    import shutil
+    import subprocess
+
+    from toad import get_version
+
+    local_version = get_version()
+
+    if check:
+        click.echo(f"Local:  canon-tui {local_version}")
+        remote = _fetch_remote_version(branch)
+        click.echo(
+            f"Remote: canon-tui {remote} (branch={branch})"
+            if remote
+            else f"Remote: unknown (could not fetch pyproject.toml @ {branch})"
+        )
+        return
+
+    if shutil.which("uv") is None:
+        click.echo(
+            "error: uv is not on PATH. Install uv first: "
+            "curl -LsSf https://astral.sh/uv/install.sh | sh",
+            err=True,
+        )
+        sys.exit(1)
+
+    spec = f"canon-tui @ {_CANON_GIT_URL}@{branch}"
+    click.echo(f"Updating from {branch} (local: {local_version})…")
+    try:
+        subprocess.run(
+            ["uv", "tool", "install", spec, "--force", "--reinstall"],
+            check=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        click.echo(f"error: uv tool install failed (exit {exc.returncode})", err=True)
+        sys.exit(exc.returncode)
+
+    new_version = _read_installed_version()
+    if new_version and new_version != local_version:
+        click.echo(f"updated: {local_version} → {new_version}")
+    elif new_version:
+        click.echo(f"already up to date: {new_version}")
+    else:
+        click.echo("update complete (version check failed)")
+
+
+def _fetch_remote_version(branch: str) -> str | None:
+    """Best-effort read of the remote pyproject.toml version field."""
+    import re
+    import urllib.error
+    import urllib.request
+
+    url = (
+        "https://raw.githubusercontent.com/DEGAorg/canon-tui/"
+        f"{branch}/pyproject.toml"
+    )
+    try:
+        with urllib.request.urlopen(url, timeout=5) as resp:
+            body = resp.read().decode("utf-8", errors="replace")
+    except (urllib.error.URLError, TimeoutError, OSError):
+        return None
+    match = re.search(r'^version\s*=\s*"([^"]+)"', body, re.MULTILINE)
+    return match.group(1) if match else None
+
+
+def _read_installed_version() -> str | None:
+    """Read the version of the canon-tui install that's currently on PATH."""
+    import subprocess
+
+    try:
+        result = subprocess.run(
+            ["canon", "--version"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return None
+    out = (result.stdout or "").strip() or (result.stderr or "").strip()
+    return out or None
+
+
 if __name__ == "__main__":
     main()

--- a/src/toad/data/plan_execution_model.py
+++ b/src/toad/data/plan_execution_model.py
@@ -7,8 +7,9 @@ plan-execution widgets already handle:
 - :class:`toad.widgets.plan_execution_tab.PlanExecutionTab.ItemStatusChanged`
   whenever an item's ``status`` field flips,
 - :class:`toad.widgets.plan_execution_tab.PlanExecutionTab.PlanFinished`
-  the first time ``finalReview.verdict`` reaches a terminal value
-  (``SHIP`` or ``REVISE``),
+  the first time the plan reaches a terminal state — either
+  ``finalReview.result`` becomes ``SHIP``/``REVISE`` or top-level
+  ``status`` becomes ``completed``/``failed``/``aborted``,
 - log chunks delivered through callbacks registered via
   :meth:`subscribe_log` — the path the
   :class:`toad.widgets.plan_worker_log_pane.PlanWorkerLogPane` already
@@ -31,6 +32,8 @@ from __future__ import annotations
 import json
 import threading
 from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Protocol
 
@@ -38,11 +41,34 @@ from toad.widgets.plan_dep_graph import DepGraphItem
 from toad.widgets.plan_execution_tab import PlanExecutionTab
 
 
-__all__ = ["PlanExecutionModel"]
+__all__ = ["PlanExecutionModel", "TerminalInfo"]
 
 
 _TERMINAL_VERDICTS = frozenset({"SHIP", "REVISE"})
+_TERMINAL_STATUSES = frozenset({"completed", "failed", "aborted"})
 _DEFAULT_VERDICT = "running"
+_PHASE_RUNNING = "Running"
+_PHASE_REVIEW = "Review"
+_PHASE_VERIFY = "Verify"
+_PHASE_DONE = "Done"
+_PHASE_FAILED = "Failed"
+
+
+@dataclass(frozen=True)
+class TerminalInfo:
+    """Snapshot of a plan's terminal state — what the panel renders on completion."""
+
+    status: str  # "completed" | "failed" | "aborted"
+    result: str | None  # "SHIP" | "REVISE" | None (engine bailed before review)
+    pr_url: str | None
+    pr_number: int | None
+    verification_status: str | None  # "passed" | "failed" | None
+    verification_unchecked: int
+    items_shipped: int
+    items_reworked: int
+    items_total: int
+    elapsed_seconds: float | None
+    review_iterations: int
 
 
 class _MessageTarget(Protocol):
@@ -70,6 +96,10 @@ class PlanExecutionModel:
         self._issue_number: int | None = None
         self._items: list[DepGraphItem] = []
         self._verdict: str = _DEFAULT_VERDICT
+        self._status: str = "running"
+        self._phase: str = _PHASE_RUNNING
+        self._final_review_status: str = "pending"
+        self._terminal: TerminalInfo | None = None
         self._finished_emitted: bool = False
         self._started: bool = False
 
@@ -102,6 +132,21 @@ class PlanExecutionModel:
     @property
     def verdict(self) -> str:
         return self._verdict
+
+    @property
+    def status(self) -> str:
+        """Top-level orch status — running / verifying / completed / failed / aborted."""
+        return self._status
+
+    @property
+    def phase(self) -> str:
+        """Human-readable phase label: Running / Review / Verify / Done / Failed."""
+        return self._phase
+
+    @property
+    def terminal(self) -> TerminalInfo | None:
+        """Snapshot of terminal state once the plan has finished. ``None`` while running."""
+        return self._terminal
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -171,11 +216,11 @@ class PlanExecutionModel:
         issue = payload.get("issueNumber")
         self._issue_number = int(issue) if isinstance(issue, int) else None
         self._items = [self._item_from_dict(it) for it in payload.get("items", [])]
-        verdict = self._extract_verdict(payload)
-        self._verdict = verdict
-        if verdict in _TERMINAL_VERDICTS:
+        self._absorb_state_meta(payload)
+        if self._is_terminal():
             # Treat plans that are already terminal at construction as
             # having been announced — we don't replay history.
+            self._terminal = self._build_terminal_info(payload)
             self._finished_emitted = True
 
     def _scan_state(self) -> None:
@@ -191,12 +236,121 @@ class PlanExecutionModel:
                     PlanExecutionTab.ItemStatusChanged(item.id, item.status)
                 )
         self._items = new_items
-
-        verdict = self._extract_verdict(payload)
-        self._verdict = verdict
-        if verdict in _TERMINAL_VERDICTS and not self._finished_emitted:
+        self._absorb_state_meta(payload)
+        if self._is_terminal() and not self._finished_emitted:
+            self._terminal = self._build_terminal_info(payload)
             self._finished_emitted = True
-            self._target.post_message(PlanExecutionTab.PlanFinished(verdict))
+            self._target.post_message(
+                PlanExecutionTab.PlanFinished(self._verdict, terminal=self._terminal)
+            )
+
+    def _absorb_state_meta(self, payload: dict[str, Any]) -> None:
+        """Refresh status, finalReview.result, finalReview.status, derived phase."""
+        status = payload.get("status")
+        self._status = status if isinstance(status, str) and status else "running"
+        review = payload.get("finalReview")
+        if isinstance(review, dict):
+            result = review.get("result")
+            review_status = review.get("status")
+        else:
+            result = None
+            review_status = None
+        self._final_review_status = (
+            review_status if isinstance(review_status, str) and review_status else "pending"
+        )
+        if isinstance(result, str) and result:
+            self._verdict = result
+        elif self._status in _TERMINAL_STATUSES and self._status != "completed":
+            # Engine bailed without a final review — surface the status as the verdict
+            # so the rail badge has something distinct to colour.
+            self._verdict = self._status.upper()
+        else:
+            self._verdict = _DEFAULT_VERDICT
+        self._phase = self._derive_phase()
+
+    def _is_terminal(self) -> bool:
+        if self._status in _TERMINAL_STATUSES:
+            return True
+        if self._verdict in _TERMINAL_VERDICTS:
+            return True
+        return False
+
+    def _derive_phase(self) -> str:
+        if self._status == "completed":
+            return _PHASE_DONE
+        if self._status in {"failed", "aborted"}:
+            return _PHASE_FAILED
+        if self._status == "verifying":
+            return _PHASE_VERIFY
+        if self._final_review_status == "running":
+            return _PHASE_REVIEW
+        if any(item.status == "review" for item in self._items):
+            return _PHASE_REVIEW
+        return _PHASE_RUNNING
+
+    def _build_terminal_info(self, payload: dict[str, Any]) -> TerminalInfo:
+        review = payload.get("finalReview") if isinstance(payload, dict) else None
+        review = review if isinstance(review, dict) else {}
+        verification = payload.get("verification") if isinstance(payload, dict) else None
+        verification = verification if isinstance(verification, dict) else {}
+
+        result = review.get("result") if isinstance(review.get("result"), str) else None
+        pr_url = review.get("prUrl") if isinstance(review.get("prUrl"), str) else None
+        pr_number_raw = review.get("prNumber")
+        pr_number = int(pr_number_raw) if isinstance(pr_number_raw, int) else None
+
+        rework_items = review.get("reworkItems")
+        items_reworked = (
+            len(rework_items)
+            if isinstance(rework_items, list)
+            else 0
+        )
+        items_shipped = sum(1 for it in self._items if it.status == "done")
+
+        review_iters_raw = payload.get("reviewIterations")
+        review_iterations = (
+            int(review_iters_raw) if isinstance(review_iters_raw, int) else 0
+        )
+
+        verification_status_raw = verification.get("status")
+        verification_status = (
+            verification_status_raw
+            if isinstance(verification_status_raw, str) and verification_status_raw
+            else None
+        )
+        unchecked = verification.get("unchecked")
+        if isinstance(unchecked, list):
+            verification_unchecked = len(unchecked)
+        elif isinstance(unchecked, int):
+            verification_unchecked = unchecked
+        else:
+            verification_unchecked = 0
+
+        elapsed = self._elapsed_seconds(payload)
+
+        return TerminalInfo(
+            status=self._status,
+            result=result,
+            pr_url=pr_url,
+            pr_number=pr_number,
+            verification_status=verification_status,
+            verification_unchecked=verification_unchecked,
+            items_shipped=items_shipped,
+            items_reworked=items_reworked,
+            items_total=len(self._items),
+            elapsed_seconds=elapsed,
+            review_iterations=review_iterations,
+        )
+
+    @staticmethod
+    def _elapsed_seconds(payload: dict[str, Any]) -> float | None:
+        started = payload.get("startedAt") if isinstance(payload, dict) else None
+        updated = payload.get("updatedAt") if isinstance(payload, dict) else None
+        start_dt = _parse_iso(started)
+        end_dt = _parse_iso(updated)
+        if start_dt is None or end_dt is None:
+            return None
+        return max(0.0, (end_dt - start_dt).total_seconds())
 
     def _scan_logs(self) -> None:
         with self._lock:
@@ -238,15 +392,6 @@ class PlanExecutionModel:
         return data if isinstance(data, dict) else None
 
     @staticmethod
-    def _extract_verdict(payload: dict[str, Any]) -> str:
-        review = payload.get("finalReview")
-        if isinstance(review, dict):
-            value = review.get("verdict")
-            if isinstance(value, str) and value:
-                return value
-        return _DEFAULT_VERDICT
-
-    @staticmethod
     def _item_from_dict(data: dict[str, Any]) -> DepGraphItem:
         return DepGraphItem(
             id=int(data["id"]),
@@ -254,3 +399,17 @@ class PlanExecutionModel:
             status=str(data.get("status", "queued")),
             deps=tuple(int(d) for d in data.get("deps", [])),
         )
+
+
+def _parse_iso(raw: object) -> datetime | None:
+    """Parse an ISO-8601 timestamp (with optional trailing 'Z') to UTC."""
+    if not isinstance(raw, str) or not raw:
+        return None
+    text = raw.replace("Z", "+00:00") if raw.endswith("Z") else raw
+    try:
+        dt = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)

--- a/src/toad/widgets/builder_view.py
+++ b/src/toad/widgets/builder_view.py
@@ -168,13 +168,16 @@ class BuilderView(Widget, can_focus=True):
         )
         yield Static(id="builder-error")
         yield PipelineView(id="builder-pipeline")
+        # Stats live above the log so all the headline state (phase,
+        # status, pipeline, counts) sits at the top of the view; the
+        # log scrolls underneath.
+        yield Static("[dim]  No metrics[/]", id="builder-metrics")
         with VerticalScroll():
             yield Static(
                 "Waiting for build activity…",
                 classes="empty-state",
                 id="builder-empty-label",
             )
-        yield Static("[dim]  No metrics[/]", id="builder-metrics")
 
     async def on_canon_state_widget_canon_state_updated(
         self,

--- a/src/toad/widgets/builder_view.py
+++ b/src/toad/widgets/builder_view.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from datetime import datetime, timezone
 
 from textual.app import ComposeResult
 from textual.containers import VerticalScroll
@@ -55,12 +56,51 @@ def _status_bar(phase: str, status: str) -> str:
     return f"  Phase: {phase_text}    Status: {status_text}"
 
 
-def _render_log(entry: LogEntry) -> str:
-    """Format a single log entry with level-based coloring."""
+def _render_log(entry: LogEntry, *, now: datetime | None = None) -> str:
+    """Format a single log entry with level-based coloring.
+
+    Timestamp renders friendly: "just now" / "12s ago" / "4m ago" /
+    "17:12" / "Apr 30 17:12" depending on age. Falls back to the raw
+    timestamp's last 8 chars if it can't be parsed as ISO.
+    """
     color = LOG_LEVEL_COLORS.get(entry.level, "white")
-    ts = entry.timestamp[-8:] if entry.timestamp else ""
-    ts_markup = f"[dim]{ts}[/] " if ts else ""
+    ts = _format_friendly_timestamp(entry.timestamp, now=now)
+    ts_markup = f"[dim]{ts:<10}[/] " if ts else ""
     return f"  {ts_markup}[{color}]{entry.message}[/]"
+
+
+def _format_friendly_timestamp(
+    raw: str, *, now: datetime | None = None
+) -> str:
+    """Convert an ISO timestamp into a human-friendly relative/clock label."""
+    if not raw:
+        return ""
+    parsed = _parse_iso(raw)
+    if parsed is None:
+        # Last-resort: trim long timestamps to HH:MM:SS so the column stays narrow.
+        return raw[-8:] if len(raw) >= 8 else raw
+    current = now or datetime.now(timezone.utc)
+    delta = (current - parsed).total_seconds()
+    if delta < 5:
+        return "just now"
+    if delta < 60:
+        return f"{int(delta)}s ago"
+    if delta < 3600:
+        return f"{int(delta // 60)}m ago"
+    if delta < 86400:
+        return parsed.astimezone().strftime("%H:%M")
+    return parsed.astimezone().strftime("%b %d %H:%M")
+
+
+def _parse_iso(raw: str) -> datetime | None:
+    text = raw.replace("Z", "+00:00") if raw.endswith("Z") else raw
+    try:
+        dt = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
 
 
 def _render_metrics(metrics: tuple[tuple[str, object], ...]) -> str:
@@ -177,9 +217,16 @@ class BuilderView(Widget, can_focus=True):
                 )
             )
         else:
-            widgets = [Static(_render_log(entry)) for entry in logs]
+            # Reverse so the newest entry sits at the top of the scroll
+            # area; older entries scroll down. The scroll position stays
+            # at home (0,0) by default which keeps the most recent line
+            # visible without yanking the user back when new lines land.
+            now = datetime.now(timezone.utc)
+            widgets = [
+                Static(_render_log(entry, now=now)) for entry in reversed(logs)
+            ]
             await scroll.mount_all(widgets)
-            scroll.scroll_end(animate=False)
+            scroll.scroll_home(animate=False)
 
         # Metrics
         metrics_widget = self.query_one("#builder-metrics", Static)

--- a/src/toad/widgets/builder_view.py
+++ b/src/toad/widgets/builder_view.py
@@ -47,6 +47,32 @@ LOG_LEVEL_COLORS: dict[str, str] = {
 }
 
 
+# Core writes raw metric keys (cycles, signals, markets, …) into
+# state.metrics. The TUI applies these aliases at render time so the
+# panel reads naturally even before core renames the keys. When core
+# updates the key, drop the alias here.
+METRIC_LABEL_ALIASES: dict[str, str] = {
+    "cycles": "Runs",
+    "runs": "Runs",
+    "signals": "Opportunities",
+    "opportunities": "Opportunities",
+    "games": "Games",
+    "markets": "Markets",
+    "errors": "Errors",
+    "mode": "Mode",
+}
+
+
+def _humanize_metric_key(raw: str) -> str:
+    """Map a core-written metric key to its user-facing label."""
+    aliased = METRIC_LABEL_ALIASES.get(raw.lower())
+    if aliased is not None:
+        return aliased
+    # Fallback: turn snake_case / kebab-case into Title Case so unknown
+    # keys still look intentional.
+    return raw.replace("_", " ").replace("-", " ").strip().title() or raw
+
+
 def _status_bar(phase: str, status: str) -> str:
     """Render phase + status as a single-line bar."""
     phase_color = PHASE_COLORS.get(phase, "dim")
@@ -104,11 +130,11 @@ def _parse_iso(raw: str) -> datetime | None:
 
 
 def _render_metrics(metrics: tuple[tuple[str, object], ...]) -> str:
-    """Render metrics as a key-value grid."""
+    """Render metrics as a key-value grid with humanised labels."""
     if not metrics:
         return "  [dim]No metrics[/]"
     lines: list[str] = []
-    pairs = list(metrics)
+    pairs = [(_humanize_metric_key(k), v) for k, v in metrics]
     for i in range(0, len(pairs), 2):
         k1, v1 = pairs[i]
         left = f"  [bold]{k1}:[/] {v1}"

--- a/src/toad/widgets/plan_donut.py
+++ b/src/toad/widgets/plan_donut.py
@@ -1,0 +1,93 @@
+"""PlanDonut — compact 2-row progress gauge for the plan-execution header.
+
+Two-row stacked layout:
+
+- Row 0 — segmented bar of fixed width. Each cell is coloured by the
+  plan item it represents (proportional mapping from cell index to
+  item index), so a glance at the bar shows the run's overall
+  composition: how many done, running, queued, failed.
+- Row 1 — bold percentage centered under the bar (``done/total``).
+
+Despite the historical class name (the first cut was a circular donut)
+the widget is now a horizontal gauge — terminal cells aren't square so
+a real ring rendered poorly. The flat bar reads cleanly at any zoom.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from rich.text import Text
+from textual.widgets import Static
+
+from toad.widgets.plan_dep_graph import DepGraphItem
+from toad.widgets.plan_status_rail import STATUS_COLORS
+
+
+__all__ = ["PlanDonut"]
+
+
+_BAR_WIDTH = 12
+_BAR_GLYPH = "█"
+_EMPTY_GLYPH = "·"
+_EMPTY_COLOR = "grey30"
+_FALLBACK_COLOR = "white"
+
+
+class PlanDonut(Static):
+    """Compact 2-row gauge — segmented bar plus percent label."""
+
+    DEFAULT_CSS = """
+    PlanDonut {
+        width: 12;
+        height: 2;
+        background: $panel;
+        color: $text;
+        padding: 0;
+        content-align: center middle;
+    }
+    """
+
+    def __init__(
+        self,
+        *,
+        items: Sequence[DepGraphItem] | None = None,
+        name: str | None = None,
+        id: str | None = None,
+        classes: str | None = None,
+    ) -> None:
+        super().__init__(name=name, id=id, classes=classes)
+        self._items: list[DepGraphItem] = list(items) if items else []
+
+    def set_items(self, items: Sequence[DepGraphItem]) -> None:
+        """Replace items and re-render."""
+        self._items = list(items)
+        self.refresh()
+
+    def render(self) -> Text:
+        return self._build()
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _build(self) -> Text:
+        total = len(self._items)
+        done = sum(1 for it in self._items if it.status == "done")
+        out = Text()
+        for col in range(_BAR_WIDTH):
+            if total == 0:
+                out.append(_EMPTY_GLYPH, style=_EMPTY_COLOR)
+                continue
+            item_index = (col * total) // _BAR_WIDTH
+            item = self._items[item_index]
+            color = STATUS_COLORS.get(item.status, _FALLBACK_COLOR)
+            out.append(_BAR_GLYPH, style=color)
+        out.append("\n")
+        if total == 0:
+            label = "—"
+        else:
+            pct = round(done * 100 / total)
+            label = f"{done}/{total} {pct:>3d}%"
+        out.append(label.center(_BAR_WIDTH), style="bold")
+        return out

--- a/src/toad/widgets/plan_execution_section.py
+++ b/src/toad/widgets/plan_execution_section.py
@@ -307,9 +307,21 @@ class PlanExecutionSection(Vertical):
     # Empty-state list — open / mark-crashed / remove buttons
     # ------------------------------------------------------------------
 
+    @on(PlanExecutionTab.CloseRequested)
+    def _on_plan_close_requested(
+        self, event: PlanExecutionTab.CloseRequested
+    ) -> None:
+        event.stop()
+        self.close_tab(event.slug)
+
     @on(Button.Pressed)
     def _on_plan_list_button(self, event: Button.Pressed) -> None:
         btn_id = event.button.id or ""
+        # Buttons inside an open plan tab (close, open-PR) are handled in
+        # PlanExecutionTab — ignore them at the section level so we don't
+        # mis-route their presses through the empty-state list.
+        if btn_id.startswith("plan-exec-"):
+            return
         slug: str | None = None
         action: str | None = None
         for prefix, name in (

--- a/src/toad/widgets/plan_execution_tab.py
+++ b/src/toad/widgets/plan_execution_tab.py
@@ -429,9 +429,6 @@ class PlanExecutionTab(TabPane):
         running = sum(1 for item in self._items if item.status == "running")
         failed = sum(1 for item in self._items if item.status == "failed")
         total = len(self._items)
-        agent = (
-            self._get_current_agent() if self._get_current_agent else _DEFAULT_AGENT
-        )
         terminal = self._terminal
 
         parts: list[str] = [slug]
@@ -447,7 +444,6 @@ class PlanExecutionTab(TabPane):
             parts.append(f"PR #{terminal.pr_number}")
         if terminal is not None and terminal.elapsed_seconds is not None:
             parts.append(_format_elapsed(terminal.elapsed_seconds))
-        parts.append(f"agent: {agent}")
         first_line = "  ".join(parts)
 
         details = self._format_terminal_details()

--- a/src/toad/widgets/plan_execution_tab.py
+++ b/src/toad/widgets/plan_execution_tab.py
@@ -146,20 +146,19 @@ class PlanExecutionTab(TabPane):
 
     DEFAULT_CSS = """
     PlanExecutionTab #plan-exec-header-row {
-        height: auto;
-        max-height: 3;
+        height: 1;
         background: $panel;
     }
     PlanExecutionTab #plan-exec-header-text {
-        height: auto;
+        height: 1;
         background: $panel;
         color: $text;
         padding: 0 1;
         width: 1fr;
     }
     PlanExecutionTab PlanProgress {
-        width: 12;
-        height: 2;
+        width: 17;
+        height: 1;
         margin: 0 1 0 0;
     }
     PlanExecutionTab #plan-exec-header-row Button {
@@ -440,16 +439,16 @@ class PlanExecutionTab(TabPane):
             parts.append(f"◉{running}")
         if failed:
             parts.append(f"✗{failed}")
-        if terminal is not None and terminal.pr_number is not None:
-            parts.append(f"PR #{terminal.pr_number}")
-        if terminal is not None and terminal.elapsed_seconds is not None:
-            parts.append(_format_elapsed(terminal.elapsed_seconds))
-        first_line = "  ".join(parts)
-
-        details = self._format_terminal_details()
-        if details:
-            return f"{first_line}\n{details}"
-        return first_line
+        if terminal is not None:
+            if terminal.pr_number is not None:
+                parts.append(f"PR #{terminal.pr_number}")
+            if terminal.elapsed_seconds is not None:
+                parts.append(_format_elapsed(terminal.elapsed_seconds))
+            if terminal.items_reworked:
+                parts.append(f"{terminal.items_reworked} reworked")
+            if terminal.review_iterations:
+                parts.append(f"{terminal.review_iterations} reviews")
+        return "  ".join(parts)
 
     def _status_badge(self, terminal: "TerminalInfo | None") -> str:
         """One-token state for the header — keeps the rail's signal at the top."""
@@ -478,24 +477,6 @@ class PlanExecutionTab(TabPane):
         # green and the badge reads as a state, not a heading).
         phase = getattr(self._model, "phase", _phase_from_verdict(self._verdict))
         return f"⟲ {phase.lower()}" if phase else self._verdict
-
-    def _format_terminal_details(self) -> str:
-        """Second header line — only used when there's something extra to say.
-
-        PR URL is reachable through the ``→ PR`` button, so it's not echoed
-        here. Verify state is intentionally hidden — it's advisory in the
-        engine and renders confusingly next to ``✓ Completed (SHIP)``.
-        """
-        terminal = self._terminal
-        if terminal is None:
-            return ""
-        bits: list[str] = []
-        if terminal.items_reworked:
-            bits.append(f"{terminal.items_reworked} reworked")
-        if terminal.review_iterations:
-            bits.append(f"{terminal.review_iterations} reviews")
-        return "  ".join(bits)
-
 
 def _phase_from_verdict(verdict: str) -> str:
     if verdict == "SHIP":

--- a/src/toad/widgets/plan_execution_tab.py
+++ b/src/toad/widgets/plan_execution_tab.py
@@ -172,12 +172,29 @@ class PlanExecutionTab(TabPane):
     PlanExecutionTab #plan-exec-header-row Button.hidden {
         display: none;
     }
+    /* Action button — accent-coloured, treated like a primary verb. */
     PlanExecutionTab #plan-exec-pr-btn {
         color: $accent;
+        text-style: bold;
     }
+    PlanExecutionTab #plan-exec-pr-btn:hover {
+        background: $accent 25%;
+    }
+    /* Destructive corner action — visually subdued so it doesn't compete
+       with the action button next to it. Lights up red only on hover or
+       focus to make "this kills the tab" intent unambiguous. The extra
+       left margin separates it from the action group. */
     PlanExecutionTab #plan-exec-close-btn {
         min-width: 3;
+        margin: 0 1 0 2;
+        background: transparent;
+        color: $text-muted;
+    }
+    PlanExecutionTab #plan-exec-close-btn:hover,
+    PlanExecutionTab #plan-exec-close-btn:focus {
         color: $error;
+        background: $error 20%;
+        text-style: bold;
     }
     PlanExecutionTab Vertical.plan-exec-body {
         height: 1fr;

--- a/src/toad/widgets/plan_execution_tab.py
+++ b/src/toad/widgets/plan_execution_tab.py
@@ -26,11 +26,13 @@ from collections.abc import Callable, Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
+import webbrowser
+
 from textual.app import ComposeResult
 from textual.containers import Horizontal, Vertical
 from textual.message import Message
 from textual.timer import Timer
-from textual.widgets import Static, TabPane
+from textual.widgets import Button, Static, TabPane
 
 from toad.directory_watcher import DirectoryChanged, DirectoryWatcher
 from toad.widgets.plan_dep_graph import DepGraphItem, PlanDepGraph
@@ -96,6 +98,24 @@ class PlanExecutionTab(TabPane):
         height: 2;
         margin: 0 1 0 0;
     }
+    PlanExecutionTab #plan-exec-header-row Button {
+        height: 1;
+        min-width: 5;
+        border: none;
+        background: $surface;
+        color: $text;
+        margin: 0 1 0 0;
+    }
+    PlanExecutionTab #plan-exec-header-row Button.hidden {
+        display: none;
+    }
+    PlanExecutionTab #plan-exec-pr-btn {
+        color: $accent;
+    }
+    PlanExecutionTab #plan-exec-close-btn {
+        min-width: 3;
+        color: $error;
+    }
     PlanExecutionTab Vertical.plan-exec-body {
         height: 1fr;
     }
@@ -115,6 +135,13 @@ class PlanExecutionTab(TabPane):
             super().__init__()
             self.item_id = item_id
             self.status = status
+
+    class CloseRequested(Message):
+        """User clicked the tab's close button."""
+
+        def __init__(self, slug: str) -> None:
+            super().__init__()
+            self.slug = slug
 
     class PlanFinished(Message):
         """Plan reached terminal state.
@@ -174,6 +201,7 @@ class PlanExecutionTab(TabPane):
         self._poll_timer = self.set_interval(
             _POLL_INTERVAL_SECONDS, self._model.poll_now
         )
+        self._refresh_pr_button()
 
     def on_unmount(self) -> None:
         if self._watcher is not None:
@@ -200,6 +228,17 @@ class PlanExecutionTab(TabPane):
                 yield PlanDonut(
                     items=self._items,
                     id="plan-exec-donut",
+                )
+                yield Button(
+                    "→ PR",
+                    id="plan-exec-pr-btn",
+                    classes="hidden",
+                    tooltip="Open the PR for this plan in your browser",
+                )
+                yield Button(
+                    "✕",
+                    id="plan-exec-close-btn",
+                    tooltip="Close this plan tab",
                 )
             yield PlanDepGraph(items=self._items, id="plan-exec-graph")
             yield PlanWorkerLogPane(
@@ -264,7 +303,18 @@ class PlanExecutionTab(TabPane):
         if event.terminal is not None:
             self._terminal = event.terminal
         self.query_one(PlanDonut).set_items(self._items)
+        self._refresh_pr_button()
         self._refresh_header()
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "plan-exec-close-btn":
+            event.stop()
+            self.post_message(self.CloseRequested(self._model.slug))
+        elif event.button.id == "plan-exec-pr-btn":
+            event.stop()
+            url = self._terminal.pr_url if self._terminal else None
+            if url:
+                webbrowser.open(url)
 
     # ------------------------------------------------------------------
     # Internals
@@ -273,6 +323,17 @@ class PlanExecutionTab(TabPane):
     def _refresh_header(self) -> None:
         header = self.query_one("#plan-exec-header-text", Static)
         header.update(self._compute_header_text())
+
+    def _refresh_pr_button(self) -> None:
+        try:
+            btn = self.query_one("#plan-exec-pr-btn", Button)
+        except Exception:
+            return
+        has_pr = self._terminal is not None and bool(self._terminal.pr_url)
+        if has_pr:
+            btn.remove_class("hidden")
+        else:
+            btn.add_class("hidden")
 
     def _compute_header_text(self) -> str:
         slug = self._model.slug
@@ -336,18 +397,16 @@ class PlanExecutionTab(TabPane):
         return f"⟲ {phase.lower()}" if phase else self._verdict
 
     def _format_terminal_details(self) -> str:
-        """Second header line — only used when there's something extra to say."""
+        """Second header line — only used when there's something extra to say.
+
+        PR URL is reachable through the ``→ PR`` button, so it's not echoed
+        here. Verify state is intentionally hidden — it's advisory in the
+        engine and renders confusingly next to ``✓ Completed (SHIP)``.
+        """
         terminal = self._terminal
         if terminal is None:
             return ""
         bits: list[str] = []
-        if terminal.pr_url:
-            bits.append(terminal.pr_url)
-        if terminal.verification_status:
-            verify = f"verify: {terminal.verification_status}"
-            if terminal.verification_unchecked:
-                verify += f" ({terminal.verification_unchecked} unchecked)"
-            bits.append(verify)
         if terminal.items_reworked:
             bits.append(f"{terminal.items_reworked} reworked")
         if terminal.review_iterations:

--- a/src/toad/widgets/plan_execution_tab.py
+++ b/src/toad/widgets/plan_execution_tab.py
@@ -26,21 +26,85 @@ from collections.abc import Callable, Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
-import webbrowser
-
 from textual.app import ComposeResult
 from textual.containers import Horizontal, Vertical
 from textual.message import Message
+from textual.screen import ModalScreen
 from textual.timer import Timer
-from textual.widgets import Button, Static, TabPane
+from textual.widgets import Button, Label, Static, TabPane
 
+from toad.acp import messages as acp_messages
 from toad.directory_watcher import DirectoryChanged, DirectoryWatcher
 from toad.widgets.plan_dep_graph import DepGraphItem, PlanDepGraph
-from toad.widgets.plan_donut import PlanDonut
+from toad.widgets.plan_progress import PlanProgress
 from toad.widgets.plan_worker_log_pane import PlanWorkerLogPane
 
 if TYPE_CHECKING:
     from toad.data.plan_execution_model import TerminalInfo
+
+
+class _CloseRunningPlanModal(ModalScreen[bool]):
+    """Confirm closing a tab while the orchestrator run is still live.
+
+    The tmux session keeps running regardless — closing only hides the
+    view. This modal makes that explicit and lets the user back out.
+    """
+
+    DEFAULT_CSS = """
+    _CloseRunningPlanModal {
+        align: center middle;
+    }
+    _CloseRunningPlanModal #dialog {
+        width: 60;
+        height: auto;
+        max-height: 12;
+        padding: 1 2;
+        background: $panel;
+        border: thick $primary;
+    }
+    _CloseRunningPlanModal #dialog Label.title {
+        text-style: bold;
+        color: $text;
+        margin-bottom: 1;
+    }
+    _CloseRunningPlanModal #dialog Label.body {
+        color: $text-muted;
+        margin-bottom: 1;
+    }
+    _CloseRunningPlanModal #dialog Horizontal {
+        height: auto;
+        align: right middle;
+    }
+    _CloseRunningPlanModal #dialog Button {
+        margin-left: 1;
+    }
+    """
+
+    BINDINGS = [("escape", "cancel", "Cancel")]
+
+    def __init__(self, slug: str) -> None:
+        super().__init__()
+        self._slug = slug
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="dialog"):
+            yield Label(f"Close “{self._slug}” view?", classes="title")
+            yield Label(
+                "The orchestrator process keeps running in tmux. Closing "
+                "only hides this tab — ask the agent to reopen it later "
+                "(e.g. “show me the plan tab”).",
+                classes="body",
+            )
+            with Horizontal():
+                yield Button("Cancel", id="cancel")
+                yield Button("Close view", id="confirm", variant="warning")
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        event.stop()
+        self.dismiss(event.button.id == "confirm")
+
+    def action_cancel(self) -> None:
+        self.dismiss(False)
 
 
 _POLL_INTERVAL_SECONDS = 2.5
@@ -93,7 +157,7 @@ class PlanExecutionTab(TabPane):
         padding: 0 1;
         width: 1fr;
     }
-    PlanExecutionTab PlanDonut {
+    PlanExecutionTab PlanProgress {
         width: 12;
         height: 2;
         margin: 0 1 0 0;
@@ -225,7 +289,7 @@ class PlanExecutionTab(TabPane):
                     self._compute_header_text(),
                     id="plan-exec-header-text",
                 )
-                yield PlanDonut(
+                yield PlanProgress(
                     items=self._items,
                     id="plan-exec-donut",
                 )
@@ -276,7 +340,7 @@ class PlanExecutionTab(TabPane):
         event.stop()
         self._items = list(event.items)
         self.query_one(PlanDepGraph).set_items(self._items)
-        self.query_one(PlanDonut).set_items(self._items)
+        self.query_one(PlanProgress).set_items(self._items)
         self._refresh_header()
 
     def on_plan_execution_tab_item_status_changed(
@@ -293,7 +357,7 @@ class PlanExecutionTab(TabPane):
                 )
                 break
         self.query_one(PlanDepGraph).set_items(self._items)
-        self.query_one(PlanDonut).set_items(self._items)
+        self.query_one(PlanProgress).set_items(self._items)
         self._refresh_header()
 
     def on_plan_execution_tab_plan_finished(self, event: PlanFinished) -> None:
@@ -302,19 +366,42 @@ class PlanExecutionTab(TabPane):
         self._verdict = event.verdict
         if event.terminal is not None:
             self._terminal = event.terminal
-        self.query_one(PlanDonut).set_items(self._items)
+        self.query_one(PlanProgress).set_items(self._items)
         self._refresh_pr_button()
         self._refresh_header()
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
         if event.button.id == "plan-exec-close-btn":
             event.stop()
-            self.post_message(self.CloseRequested(self._model.slug))
+            self._handle_close()
         elif event.button.id == "plan-exec-pr-btn":
             event.stop()
-            url = self._terminal.pr_url if self._terminal else None
-            if url:
-                webbrowser.open(url)
+            self._open_pr_view()
+
+    def _open_pr_view(self) -> None:
+        """Switch the right pane to the in-TUI PR list, narrowed if possible."""
+        slug = self._model.slug
+        # Try to narrow to this run's PR by title — orch-engine titles PRs
+        # ``plan: <slug>``. If the user's PR-list filter doesn't match by
+        # substring it'll just open the unfiltered list.
+        filters: dict[str, Any] = {"title": slug} if slug else {}
+        context = {"filters": filters} if filters else None
+        self.post_message(acp_messages.OpenPanel("prs", context=context))
+
+    def _handle_close(self) -> None:
+        if self._terminal is not None:
+            # Plan already reached terminal — closing is harmless.
+            self.post_message(self.CloseRequested(self._model.slug))
+            return
+
+        def _on_dismiss(confirmed: bool | None) -> None:
+            if confirmed:
+                self.post_message(self.CloseRequested(self._model.slug))
+
+        self.app.push_screen(
+            _CloseRunningPlanModal(self._model.slug),
+            _on_dismiss,
+        )
 
     # ------------------------------------------------------------------
     # Internals

--- a/src/toad/widgets/plan_execution_tab.py
+++ b/src/toad/widgets/plan_execution_tab.py
@@ -24,18 +24,22 @@ from __future__ import annotations
 
 from collections.abc import Callable, Sequence
 from pathlib import Path
-from typing import Any, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 from textual.app import ComposeResult
-from textual.containers import Vertical
+from textual.containers import Horizontal, Vertical
 from textual.message import Message
 from textual.timer import Timer
 from textual.widgets import Static, TabPane
 
 from toad.directory_watcher import DirectoryChanged, DirectoryWatcher
 from toad.widgets.plan_dep_graph import DepGraphItem, PlanDepGraph
+from toad.widgets.plan_donut import PlanDonut
 from toad.widgets.plan_status_rail import PlanStatusRail, RailItem
 from toad.widgets.plan_worker_log_pane import PlanWorkerLogPane
+
+if TYPE_CHECKING:
+    from toad.data.plan_execution_model import TerminalInfo
 
 
 _POLL_INTERVAL_SECONDS = 2.5
@@ -76,11 +80,21 @@ class PlanExecutionTab(TabPane):
     """One-plan tab composing header + dep graph + worker log + status rail."""
 
     DEFAULT_CSS = """
-    PlanExecutionTab #plan-exec-header {
-        height: 1;
+    PlanExecutionTab #plan-exec-header-row {
+        height: 2;
+        background: $panel;
+    }
+    PlanExecutionTab #plan-exec-header-text {
+        height: 2;
         background: $panel;
         color: $text;
         padding: 0 1;
+        width: 1fr;
+    }
+    PlanExecutionTab PlanDonut {
+        width: 12;
+        height: 2;
+        margin: 0 1 0 0;
     }
     PlanExecutionTab Vertical.plan-exec-body {
         height: 1fr;
@@ -103,11 +117,26 @@ class PlanExecutionTab(TabPane):
             self.status = status
 
     class PlanFinished(Message):
-        """Plan reached terminal state; verdict is SHIP or REVISE."""
+        """Plan reached terminal state.
 
-        def __init__(self, verdict: str) -> None:
+        ``verdict`` carries the rail badge label — typically ``SHIP`` or
+        ``REVISE`` from ``finalReview.result``, or ``FAILED`` / ``ABORTED``
+        when the engine bails out without a final review.
+
+        ``terminal`` carries the structured snapshot (PR URL, verification,
+        summary) the tab uses to render the completion banner. ``None``
+        when the message comes from a caller that hasn't built one (some
+        tests post a bare verdict).
+        """
+
+        def __init__(
+            self,
+            verdict: str,
+            terminal: "TerminalInfo | None" = None,
+        ) -> None:
             super().__init__()
             self.verdict = verdict
+            self.terminal = terminal
 
     def __init__(
         self,
@@ -127,6 +156,7 @@ class PlanExecutionTab(TabPane):
         self._get_current_agent = get_current_agent
         self._items: list[DepGraphItem] = list(model.items)
         self._verdict: str = model.verdict
+        self._terminal: "TerminalInfo | None" = getattr(model, "terminal", None)
         self._selected_item_id: int | None = None
         self._poll_timer: Timer | None = None
         self._watcher: DirectoryWatcher | None = None
@@ -162,7 +192,15 @@ class PlanExecutionTab(TabPane):
 
     def compose(self) -> ComposeResult:
         with Vertical(classes="plan-exec-body"):
-            yield Static(self._compute_header_text(), id="plan-exec-header")
+            with Horizontal(id="plan-exec-header-row"):
+                yield Static(
+                    self._compute_header_text(),
+                    id="plan-exec-header-text",
+                )
+                yield PlanDonut(
+                    items=self._items,
+                    id="plan-exec-donut",
+                )
             yield PlanDepGraph(items=self._items, id="plan-exec-graph")
             yield PlanWorkerLogPane(
                 model=self._model,
@@ -205,6 +243,7 @@ class PlanExecutionTab(TabPane):
         self._items = list(event.items)
         self.query_one(PlanDepGraph).set_items(self._items)
         self.query_one(PlanStatusRail).set_items(self._rail_items())
+        self.query_one(PlanDonut).set_items(self._items)
         self._refresh_header()
 
     def on_plan_execution_tab_item_status_changed(
@@ -224,13 +263,17 @@ class PlanExecutionTab(TabPane):
         self.query_one(PlanStatusRail).post_message(
             PlanStatusRail.ItemStatusChanged(event.item_id, event.status)
         )
+        self.query_one(PlanDonut).set_items(self._items)
         self._refresh_header()
 
     def on_plan_execution_tab_plan_finished(self, event: PlanFinished) -> None:
         """Flip verdict on completion. Tab stays mounted."""
         event.stop()
         self._verdict = event.verdict
+        if event.terminal is not None:
+            self._terminal = event.terminal
         self.query_one(PlanStatusRail).set_verdict(event.verdict)
+        self.query_one(PlanDonut).set_items(self._items)
         self._refresh_header()
 
     # ------------------------------------------------------------------
@@ -241,7 +284,7 @@ class PlanExecutionTab(TabPane):
         return [RailItem(id=i.id, status=i.status) for i in self._items]
 
     def _refresh_header(self) -> None:
-        header = self.query_one("#plan-exec-header", Static)
+        header = self.query_one("#plan-exec-header-text", Static)
         header.update(self._compute_header_text())
 
     def _compute_header_text(self) -> str:
@@ -254,15 +297,67 @@ class PlanExecutionTab(TabPane):
         agent = (
             self._get_current_agent() if self._get_current_agent else _DEFAULT_AGENT
         )
-        parts = [slug]
+        phase = getattr(self._model, "phase", _phase_from_verdict(self._verdict))
+        first_line_parts = [slug]
         if issue is not None:
-            parts.append(f"#{issue}")
-        parts.append(self._verdict)
+            first_line_parts.append(f"#{issue}")
+        first_line_parts.append(f"[{phase}]")
+        first_line_parts.append(self._verdict)
         counters = [f"✓{done}/{total}"]
         if running:
             counters.append(f"◉{running}")
         if failed:
             counters.append(f"✗{failed}")
-        parts.append(" ".join(counters))
-        parts.append(f"agent: {agent}")
-        return "  ".join(parts)
+        first_line_parts.append(" ".join(counters))
+        first_line_parts.append(f"agent: {agent}")
+        first_line = "  ".join(first_line_parts)
+
+        terminal_line = self._format_terminal_line()
+        if terminal_line:
+            return f"{first_line}\n{terminal_line}"
+        return first_line
+
+    def _format_terminal_line(self) -> str:
+        terminal = self._terminal
+        if terminal is None:
+            return ""
+        bits: list[str] = []
+        if terminal.pr_number is not None:
+            label = f"PR #{terminal.pr_number}"
+            if terminal.pr_url:
+                bits.append(f"{label}  {terminal.pr_url}")
+            else:
+                bits.append(label)
+        elif terminal.pr_url:
+            bits.append(f"PR  {terminal.pr_url}")
+        if terminal.verification_status:
+            verify = f"verify: {terminal.verification_status}"
+            if terminal.verification_unchecked:
+                verify += f" ({terminal.verification_unchecked} unchecked)"
+            bits.append(verify)
+        summary = (
+            f"{terminal.items_shipped}/{terminal.items_total} shipped"
+        )
+        if terminal.items_reworked:
+            summary += f", {terminal.items_reworked} reworked"
+        bits.append(summary)
+        if terminal.elapsed_seconds is not None:
+            bits.append(f"elapsed: {_format_elapsed(terminal.elapsed_seconds)}")
+        return "  ".join(bits)
+
+
+def _phase_from_verdict(verdict: str) -> str:
+    if verdict == "SHIP":
+        return "Done"
+    if verdict in {"REVISE", "FAILED", "ABORTED"}:
+        return "Failed"
+    return "Running"
+
+
+def _format_elapsed(seconds: float) -> str:
+    total = int(seconds)
+    minutes, sec = divmod(total, 60)
+    hours, minutes = divmod(minutes, 60)
+    if hours:
+        return f"{hours}h {minutes:02d}m {sec:02d}s"
+    return f"{minutes}m {sec:02d}s"

--- a/src/toad/widgets/plan_execution_tab.py
+++ b/src/toad/widgets/plan_execution_tab.py
@@ -35,7 +35,6 @@ from textual.widgets import Static, TabPane
 from toad.directory_watcher import DirectoryChanged, DirectoryWatcher
 from toad.widgets.plan_dep_graph import DepGraphItem, PlanDepGraph
 from toad.widgets.plan_donut import PlanDonut
-from toad.widgets.plan_status_rail import PlanStatusRail, RailItem
 from toad.widgets.plan_worker_log_pane import PlanWorkerLogPane
 
 if TYPE_CHECKING:
@@ -81,11 +80,12 @@ class PlanExecutionTab(TabPane):
 
     DEFAULT_CSS = """
     PlanExecutionTab #plan-exec-header-row {
-        height: 2;
+        height: auto;
+        max-height: 3;
         background: $panel;
     }
     PlanExecutionTab #plan-exec-header-text {
-        height: 2;
+        height: auto;
         background: $panel;
         color: $text;
         padding: 0 1;
@@ -207,11 +207,6 @@ class PlanExecutionTab(TabPane):
                 item_id=None,
                 id="plan-exec-log",
             )
-            yield PlanStatusRail(
-                items=self._rail_items(),
-                verdict=self._verdict,
-                id="plan-exec-rail",
-            )
 
     # ------------------------------------------------------------------
     # Public helpers
@@ -242,7 +237,6 @@ class PlanExecutionTab(TabPane):
         event.stop()
         self._items = list(event.items)
         self.query_one(PlanDepGraph).set_items(self._items)
-        self.query_one(PlanStatusRail).set_items(self._rail_items())
         self.query_one(PlanDonut).set_items(self._items)
         self._refresh_header()
 
@@ -260,9 +254,6 @@ class PlanExecutionTab(TabPane):
                 )
                 break
         self.query_one(PlanDepGraph).set_items(self._items)
-        self.query_one(PlanStatusRail).post_message(
-            PlanStatusRail.ItemStatusChanged(event.item_id, event.status)
-        )
         self.query_one(PlanDonut).set_items(self._items)
         self._refresh_header()
 
@@ -272,16 +263,12 @@ class PlanExecutionTab(TabPane):
         self._verdict = event.verdict
         if event.terminal is not None:
             self._terminal = event.terminal
-        self.query_one(PlanStatusRail).set_verdict(event.verdict)
         self.query_one(PlanDonut).set_items(self._items)
         self._refresh_header()
 
     # ------------------------------------------------------------------
     # Internals
     # ------------------------------------------------------------------
-
-    def _rail_items(self) -> list[RailItem]:
-        return [RailItem(id=i.id, status=i.status) for i in self._items]
 
     def _refresh_header(self) -> None:
         header = self.query_one("#plan-exec-header-text", Static)
@@ -297,52 +284,74 @@ class PlanExecutionTab(TabPane):
         agent = (
             self._get_current_agent() if self._get_current_agent else _DEFAULT_AGENT
         )
-        phase = getattr(self._model, "phase", _phase_from_verdict(self._verdict))
-        first_line_parts = [slug]
-        if issue is not None:
-            first_line_parts.append(f"#{issue}")
-        first_line_parts.append(f"[{phase}]")
-        first_line_parts.append(self._verdict)
-        counters = [f"✓{done}/{total}"]
-        if running:
-            counters.append(f"◉{running}")
-        if failed:
-            counters.append(f"✗{failed}")
-        first_line_parts.append(" ".join(counters))
-        first_line_parts.append(f"agent: {agent}")
-        first_line = "  ".join(first_line_parts)
+        terminal = self._terminal
 
-        terminal_line = self._format_terminal_line()
-        if terminal_line:
-            return f"{first_line}\n{terminal_line}"
+        parts: list[str] = [slug]
+        if issue is not None:
+            parts.append(f"#{issue}")
+        parts.append(self._status_badge(terminal))
+        parts.append(f"{done}/{total}")
+        if terminal is None and running:
+            parts.append(f"◉{running}")
+        if failed:
+            parts.append(f"✗{failed}")
+        if terminal is not None and terminal.pr_number is not None:
+            parts.append(f"PR #{terminal.pr_number}")
+        if terminal is not None and terminal.elapsed_seconds is not None:
+            parts.append(_format_elapsed(terminal.elapsed_seconds))
+        parts.append(f"agent: {agent}")
+        first_line = "  ".join(parts)
+
+        details = self._format_terminal_details()
+        if details:
+            return f"{first_line}\n{details}"
         return first_line
 
-    def _format_terminal_line(self) -> str:
+    def _status_badge(self, terminal: "TerminalInfo | None") -> str:
+        """One-token state for the header — keeps the rail's signal at the top."""
+        if terminal is not None:
+            if terminal.status == "completed":
+                if terminal.result == "SHIP" or self._verdict == "SHIP":
+                    return "✓ Completed (SHIP)"
+                if terminal.result == "REVISE" or self._verdict == "REVISE":
+                    return "✗ Completed (REVISE)"
+                return "✓ Completed"
+            if terminal.status == "failed":
+                return f"✗ Failed ({self._verdict})" if self._verdict not in {
+                    "running", "FAILED"
+                } else "✗ Failed"
+            if terminal.status == "aborted":
+                return "⊘ Aborted"
+        # No terminal payload — the verdict alone may carry the result if a
+        # caller posted ``PlanFinished("SHIP")`` without building a snapshot.
+        if self._verdict == "SHIP":
+            return "✓ Completed (SHIP)"
+        if self._verdict == "REVISE":
+            return "✗ Completed (REVISE)"
+        if self._verdict in {"FAILED", "ABORTED"}:
+            return f"✗ {self._verdict.title()}"
+        # Live run: prefer model.phase (lowercased so existing fixtures stay
+        # green and the badge reads as a state, not a heading).
+        phase = getattr(self._model, "phase", _phase_from_verdict(self._verdict))
+        return f"⟲ {phase.lower()}" if phase else self._verdict
+
+    def _format_terminal_details(self) -> str:
+        """Second header line — only used when there's something extra to say."""
         terminal = self._terminal
         if terminal is None:
             return ""
         bits: list[str] = []
-        if terminal.pr_number is not None:
-            label = f"PR #{terminal.pr_number}"
-            if terminal.pr_url:
-                bits.append(f"{label}  {terminal.pr_url}")
-            else:
-                bits.append(label)
-        elif terminal.pr_url:
-            bits.append(f"PR  {terminal.pr_url}")
+        if terminal.pr_url:
+            bits.append(terminal.pr_url)
         if terminal.verification_status:
             verify = f"verify: {terminal.verification_status}"
             if terminal.verification_unchecked:
                 verify += f" ({terminal.verification_unchecked} unchecked)"
             bits.append(verify)
-        summary = (
-            f"{terminal.items_shipped}/{terminal.items_total} shipped"
-        )
         if terminal.items_reworked:
-            summary += f", {terminal.items_reworked} reworked"
-        bits.append(summary)
-        if terminal.elapsed_seconds is not None:
-            bits.append(f"elapsed: {_format_elapsed(terminal.elapsed_seconds)}")
+            bits.append(f"{terminal.items_reworked} reworked")
+        if terminal.review_iterations:
+            bits.append(f"{terminal.review_iterations} reviews")
         return "  ".join(bits)
 
 

--- a/src/toad/widgets/plan_progress.py
+++ b/src/toad/widgets/plan_progress.py
@@ -88,6 +88,6 @@ class PlanProgress(Static):
             label = "—"
         else:
             pct = round(done * 100 / total)
-            label = f"{done}/{total} {pct:>3d}%"
+            label = f"{pct}%"
         out.append(label.center(_BAR_WIDTH), style="bold")
         return out

--- a/src/toad/widgets/plan_progress.py
+++ b/src/toad/widgets/plan_progress.py
@@ -1,16 +1,15 @@
-"""PlanProgress — compact 2-row progress gauge for the plan-execution header.
+"""PlanProgress — single-line progress gauge for the plan-execution header.
 
-Two-row stacked layout:
+One row: a 12-cell segmented bar followed by a bold percentage.
+Each bar cell is coloured by the plan item it represents (proportional
+mapping from cell index to item index), so a glance shows the run's
+overall composition — done, running, queued, failed.
 
-- Row 0 — 12-cell segmented bar. Each cell is coloured by the plan
-  item it represents (proportional mapping from cell index to item
-  index), so a glance at the bar shows the run's overall composition:
-  how many done, running, queued, failed.
-- Row 1 — bold ``done/total <pct>%`` label centred under the bar.
-
-This widget started life as a circular donut; terminal cells aren't
-square, so the ring rendered lopsided. The flat horizontal gauge reads
-cleanly at any zoom.
+The widget started life as a circular donut, then a 2-row stack;
+terminal cells aren't square so the ring rendered lopsided, and the
+stack ate vertical space the header didn't have to spare. The flat,
+inline gauge reads cleanly at any zoom and keeps the header on a
+single line.
 """
 
 from __future__ import annotations
@@ -32,19 +31,21 @@ _BAR_GLYPH = "█"
 _EMPTY_GLYPH = "·"
 _EMPTY_COLOR = "grey30"
 _FALLBACK_COLOR = "white"
+# Bar (12) + space + percent label (up to "100%" = 4) = 17.
+_WIDGET_WIDTH = _BAR_WIDTH + 1 + 4
 
 
 class PlanProgress(Static):
-    """Compact 2-row gauge — segmented bar plus percent label."""
+    """Single-line gauge — segmented bar followed by percent label."""
 
     DEFAULT_CSS = """
     PlanProgress {
-        width: 12;
-        height: 2;
+        width: 17;
+        height: 1;
         background: $panel;
         color: $text;
         padding: 0;
-        content-align: center middle;
+        content-align: left middle;
     }
     """
 
@@ -83,11 +84,10 @@ class PlanProgress(Static):
             item = self._items[item_index]
             color = STATUS_COLORS.get(item.status, _FALLBACK_COLOR)
             out.append(_BAR_GLYPH, style=color)
-        out.append("\n")
         if total == 0:
-            label = "—"
+            label = "  —"
         else:
             pct = round(done * 100 / total)
-            label = f"{pct}%"
-        out.append(label.center(_BAR_WIDTH), style="bold")
+            label = f" {pct:>3d}%"
+        out.append(label, style="bold")
         return out

--- a/src/toad/widgets/plan_progress.py
+++ b/src/toad/widgets/plan_progress.py
@@ -1,16 +1,16 @@
-"""PlanDonut — compact 2-row progress gauge for the plan-execution header.
+"""PlanProgress — compact 2-row progress gauge for the plan-execution header.
 
 Two-row stacked layout:
 
-- Row 0 — segmented bar of fixed width. Each cell is coloured by the
-  plan item it represents (proportional mapping from cell index to
-  item index), so a glance at the bar shows the run's overall
-  composition: how many done, running, queued, failed.
-- Row 1 — bold percentage centered under the bar (``done/total``).
+- Row 0 — 12-cell segmented bar. Each cell is coloured by the plan
+  item it represents (proportional mapping from cell index to item
+  index), so a glance at the bar shows the run's overall composition:
+  how many done, running, queued, failed.
+- Row 1 — bold ``done/total <pct>%`` label centred under the bar.
 
-Despite the historical class name (the first cut was a circular donut)
-the widget is now a horizontal gauge — terminal cells aren't square so
-a real ring rendered poorly. The flat bar reads cleanly at any zoom.
+This widget started life as a circular donut; terminal cells aren't
+square, so the ring rendered lopsided. The flat horizontal gauge reads
+cleanly at any zoom.
 """
 
 from __future__ import annotations
@@ -24,7 +24,7 @@ from toad.widgets.plan_dep_graph import DepGraphItem
 from toad.widgets.plan_status_rail import STATUS_COLORS
 
 
-__all__ = ["PlanDonut"]
+__all__ = ["PlanProgress"]
 
 
 _BAR_WIDTH = 12
@@ -34,11 +34,11 @@ _EMPTY_COLOR = "grey30"
 _FALLBACK_COLOR = "white"
 
 
-class PlanDonut(Static):
+class PlanProgress(Static):
     """Compact 2-row gauge — segmented bar plus percent label."""
 
     DEFAULT_CSS = """
-    PlanDonut {
+    PlanProgress {
         width: 12;
         height: 2;
         background: $panel;

--- a/src/toad/widgets/project_state_pane.py
+++ b/src/toad/widgets/project_state_pane.py
@@ -523,22 +523,26 @@ class ProjectStatePane(Vertical):
         self._sync_outreach_timer(section_id, visible=True)
 
     def show_single_section(self, section_id: str) -> None:
-        """Show ``section_id`` and hide all other sections (accordion)."""
+        """Show ``section_id`` and hide every other section (accordion).
+
+        Iterates ``self._sections`` (the live list) so dynamically-added
+        sections — Outreach when its provider is detected, Plans when
+        the orchestrator is configured — participate in the toggle the
+        same way as the static Context / Planning / State trio.
+        """
+        # The plan-exec section is mounted lazily; ensure it exists if
+        # the user clicks its toolbar button before any plan is opened.
+        if section_id == PlanExecutionSection.SECTION_ID:
+            self._ensure_plan_exec_section()
         for sec in self._sections:
             visible = sec.section_id == section_id
-            widget = self.query_one(f"#{sec.section_id}")
+            try:
+                widget = self.query_one(f"#{sec.section_id}")
+            except NoMatches:
+                continue
             widget.display = visible
             self._sync_timeline_timer(sec.section_id, visible=visible)
             self._sync_outreach_timer(sec.section_id, visible=visible)
-        self._sync_toolbar()
-
-    def show_single_section(self, section_id: str) -> None:
-        """Show ``section_id`` and hide all other sections (accordion)."""
-        for sec in SECTIONS:
-            visible = sec.section_id == section_id
-            widget = self.query_one(f"#{sec.section_id}")
-            widget.display = visible
-            self._sync_timeline_timer(sec.section_id, visible=visible)
         self._sync_toolbar()
 
     def hide_section(self, section_id: str) -> None:

--- a/src/toad/widgets/prompt.py
+++ b/src/toad/widgets/prompt.py
@@ -99,25 +99,18 @@ See on-screen instructions for details.
     BINDINGS = [
         Binding(
             "enter",
-            "submit",
+            "enter_pressed",
             "Send",
             key_display="⏎",
             priority=True,
-            tooltip="Send the prompt to the agent",
+            tooltip="Single-line: send. Multi-line: insert newline.",
         ),
         Binding(
             "ctrl+j,shift+enter",
-            "newline",
+            "shift_enter_pressed",
             "Line",
             key_display="⇧+⏎",
-            tooltip="Insert a new line character",
-        ),
-        Binding(
-            "ctrl+j,shift+enter",
-            "multiline_submit",
-            "Send",
-            key_display="⇧+⏎",
-            tooltip="Send the prompt to the agent",
+            tooltip="Single-line: insert newline. Multi-line: send.",
         ),
         Binding(
             "tab",
@@ -228,14 +221,17 @@ See on-screen instructions for details.
                     if self.text not in completes:
                         self.suggestion = completes[-1]
 
-    def check_action(self, action: str, parameters: tuple[object, ...]) -> bool | None:
-        if action == "newline" and self.multi_line:
-            return False
-        if action == "submit" and self.multi_line:
-            return False
-        if action == "multiline_submit":
-            return self.multi_line
-        return True
+    def action_enter_pressed(self) -> None:
+        if self.multi_line:
+            self.action_newline()
+        else:
+            self.action_submit()
+
+    def action_shift_enter_pressed(self) -> None:
+        if self.multi_line:
+            self.action_multiline_submit()
+        else:
+            self.action_newline()
 
     def action_multiline_submit(self) -> None:
         if not self.agent_ready:

--- a/src/toad/widgets/prompt.py
+++ b/src/toad/widgets/prompt.py
@@ -222,16 +222,10 @@ See on-screen instructions for details.
                         self.suggestion = completes[-1]
 
     def action_enter_pressed(self) -> None:
-        if self.multi_line:
-            self.action_newline()
-        else:
-            self.action_submit()
+        self.action_submit()
 
     def action_shift_enter_pressed(self) -> None:
-        if self.multi_line:
-            self.action_multiline_submit()
-        else:
-            self.action_newline()
+        self.action_newline()
 
     def action_multiline_submit(self) -> None:
         if not self.agent_ready:

--- a/src/toad/widgets/prompt.py
+++ b/src/toad/widgets/prompt.py
@@ -106,10 +106,10 @@ See on-screen instructions for details.
             tooltip="Single-line: send. Multi-line: insert newline.",
         ),
         Binding(
-            "ctrl+j,shift+enter",
+            "alt+enter,ctrl+j,shift+enter",
             "shift_enter_pressed",
             "Line",
-            key_display="⇧+⏎",
+            key_display="⌥+⏎",
             tooltip="Single-line: insert newline. Multi-line: send.",
         ),
         Binding(

--- a/tests/data/test_plan_execution_model.py
+++ b/tests/data/test_plan_execution_model.py
@@ -53,6 +53,7 @@ def _state_payload(
     verdict: str | None = None,
     issue_number: int | None = 42,
     slug: str = "20260427-test-plan",
+    status: str | None = None,
 ) -> dict[str, Any]:
     payload: dict[str, Any] = {
         "version": 1,
@@ -61,7 +62,12 @@ def _state_payload(
         "items": list(items),
     }
     if verdict is not None:
-        payload["finalReview"] = {"verdict": verdict}
+        # Engine writes finalReview.result; the parameter is named ``verdict``
+        # for readability in test bodies.
+        payload["finalReview"] = {"result": verdict, "status": "done"}
+        payload["status"] = status or "completed"
+    elif status is not None:
+        payload["status"] = status
     return payload
 
 

--- a/tests/widgets/test_plan_execution_section.py
+++ b/tests/widgets/test_plan_execution_section.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -40,12 +41,21 @@ class _StubModel:
     issue_number: int | None = 7
     items: list[Any] = field(default_factory=list)
     verdict: str = "running"
+    plan_dir: Path = field(
+        default_factory=lambda: Path("/nonexistent-stub-plan")
+    )
 
     def subscribe_log(
         self, item_id: int, callback: Callable[[str], None]
     ) -> Callable[[], None]:
         del item_id, callback
         return lambda: None
+
+    def poll_now(self) -> None:
+        return None
+
+    def set_target(self, target: Any) -> None:
+        del target
 
 
 def _factory(slug: str) -> _StubModel:

--- a/tests/widgets/test_plan_execution_tab.py
+++ b/tests/widgets/test_plan_execution_tab.py
@@ -111,12 +111,12 @@ class _Harness(App[None]):
 
 
 class TestHeader:
-    """Header shows slug, issue #, counts, verdict, and agent name."""
+    """Header shows slug, issue #, counts, and badge."""
 
     @pytest.mark.asyncio
-    async def test_header_shows_slug_issue_counts_and_agent(self) -> None:
+    async def test_header_shows_slug_issue_counts_and_badge(self) -> None:
         model = _FakeModel(items=_fixture_items())
-        app = _Harness(model, agent="claude")
+        app = _Harness(model)
         async with app.run_test() as pilot:
             await pilot.pause()
             tab = app.query_one(PlanExecutionTab)
@@ -125,16 +125,16 @@ class TestHeader:
             assert "#42" in header_text
             assert "1/4" in header_text  # one "done" out of four items
             assert "running" in header_text
-            assert "claude" in header_text
 
     @pytest.mark.asyncio
-    async def test_header_reflects_agent_callable(self) -> None:
+    async def test_header_omits_agent_token(self) -> None:
+        """Agent name was removed from the header — assert it stays out."""
         model = _FakeModel(items=_fixture_items())
-        app = _Harness(model, agent="codex")
+        app = _Harness(model)
         async with app.run_test() as pilot:
             await pilot.pause()
             tab = app.query_one(PlanExecutionTab)
-            assert "codex" in tab.header_text()
+            assert "agent:" not in tab.header_text()
 
     @pytest.mark.asyncio
     async def test_header_without_issue_number(self) -> None:

--- a/tests/widgets/test_plan_execution_tab.py
+++ b/tests/widgets/test_plan_execution_tab.py
@@ -33,7 +33,6 @@ from toad.data.plan_execution_model import PlanExecutionModel
 from toad.directory_watcher import DirectoryWatcher
 from toad.widgets.plan_dep_graph import DepGraphItem, PlanDepGraph
 from toad.widgets.plan_execution_tab import PlanExecutionTab
-from toad.widgets.plan_status_rail import STATUS_GLYPHS, PlanStatusRail
 from toad.widgets.plan_worker_log_pane import PlanWorkerLogPane
 
 
@@ -214,8 +213,6 @@ class TestPlanFinishedPersists:
             # Tab is still mounted and queryable.
             still_there = app.query_one(PlanExecutionTab)
             assert still_there is tab
-            rail = tab.query_one(PlanStatusRail)
-            assert rail.verdict_label() == "SHIP"
             assert "SHIP" in tab.header_text()
 
     @pytest.mark.asyncio
@@ -227,8 +224,6 @@ class TestPlanFinishedPersists:
             tab = app.query_one(PlanExecutionTab)
             tab.post_message(PlanExecutionTab.PlanFinished("REVISE"))
             await pilot.pause()
-            rail = tab.query_one(PlanStatusRail)
-            assert rail.verdict_label() == "REVISE"
             assert "REVISE" in tab.header_text()
             # Still mounted inside the TabbedContent.
             tabs = app.query_one(TabbedContent)
@@ -342,7 +337,7 @@ class TestLiveUpdates:
             assert tab._watcher is None  # type: ignore[attr-defined]
 
     @pytest.mark.asyncio
-    async def test_state_mutation_drives_status_change_to_rail(
+    async def test_state_mutation_drives_status_change_through_tab(
         self, live_plan_dir: Path
     ) -> None:
         target = _LateTarget()
@@ -353,12 +348,9 @@ class TestLiveUpdates:
             await pilot.pause()
             tab = app.query_one(PlanExecutionTab)
             target.target = tab
-            rail = tab.query_one(PlanStatusRail)
 
-            assert rail.glyphs_plain() == [
-                STATUS_GLYPHS["queued"],
-                STATUS_GLYPHS["queued"],
-            ]
+            # Two queued items with no done; header shows "0/2".
+            assert "0/2" in tab.header_text()
 
             # Backstop poll catches this even if watcher misses.
             await pilot.pause()
@@ -384,7 +376,8 @@ class TestLiveUpdates:
             # Allow the 2.5s backstop to fire and the message to drain.
             await pilot.pause(3.0)
 
-            assert rail.glyphs_plain() == [
-                STATUS_GLYPHS["running"],
-                STATUS_GLYPHS["queued"],
-            ]
+            # One running, one queued — header counter still 0/2 done plus
+            # an active marker on the live row.
+            text = tab.header_text()
+            assert "0/2" in text
+            assert "◉1" in text

--- a/tests/widgets/test_plan_execution_tab.py
+++ b/tests/widgets/test_plan_execution_tab.py
@@ -254,7 +254,8 @@ def _state_payload(
         "items": items,
     }
     if verdict is not None:
-        payload["finalReview"] = {"verdict": verdict}
+        payload["finalReview"] = {"result": verdict, "status": "done"}
+        payload["status"] = "completed"
     return payload
 
 

--- a/tests/widgets/test_project_state_pane_orch.py
+++ b/tests/widgets/test_project_state_pane_orch.py
@@ -55,6 +55,9 @@ class _StubModel:
     issue_number: int | None = None
     items: list[Any] = field(default_factory=list)
     verdict: str = "running"
+    plan_dir: Path = field(
+        default_factory=lambda: Path("/nonexistent-stub-plan")
+    )
     _unsub_calls: list[int] = field(default_factory=list)
 
     def subscribe_log(
@@ -66,6 +69,12 @@ class _StubModel:
             self._unsub_calls.append(item_id)
 
         return _unsubscribe
+
+    def poll_now(self) -> None:
+        return None
+
+    def set_target(self, target: Any) -> None:
+        del target
 
 
 def _make_factory() -> Callable[[str], _StubModel]:

--- a/tools/verify-tui.py
+++ b/tools/verify-tui.py
@@ -663,7 +663,6 @@ def verify_plan_execution(verbose: bool = False) -> bool:
     from toad.data.plan_execution_model import PlanExecutionModel
     from toad.widgets.plan_execution_section import PlanExecutionSection
     from toad.widgets.plan_execution_tab import PlanExecutionTab
-    from toad.widgets.plan_status_rail import STATUS_GLYPHS, PlanStatusRail
     from toad.widgets.project_state_pane import ProjectStatePane
 
     class _LateTarget:
@@ -805,48 +804,31 @@ def verify_plan_execution(verbose: bool = False) -> bool:
                     # Bind the late target so model messages reach the tab.
                     late_target.target = tab
 
-                rails = pane.query(PlanStatusRail)
-                if len(rails) != 1:
+                # Header text replaces the status rail as the primary live
+                # signal — it carries the badge, the count and the active
+                # marker.
+                header_before = tab.header_text()
+                results["header_initial"] = header_before
+                if "running" not in header_before:
                     errors.append(
-                        f"expected 1 PlanStatusRail, found {len(rails)}"
+                        f"header missing 'running' state: {header_before!r}"
                     )
-                else:
-                    rail = rails.first()
-                    glyphs = rail.glyphs_plain()
-                    results["rail_glyphs"] = glyphs
-                    results["rail_verdict"] = rail.verdict_label()
-                    if len(glyphs) != 1:
-                        errors.append(
-                            f"status rail glyph count={len(glyphs)}, expected 1"
-                        )
-                    elif glyphs[0] != STATUS_GLYPHS["running"]:
-                        errors.append(
-                            f"glyph={glyphs[0]!r}, expected running "
-                            f"{STATUS_GLYPHS['running']!r}"
-                        )
-                    if rail.verdict_label() != "running":
-                        errors.append(
-                            f"verdict={rail.verdict_label()!r}, expected 'running'"
-                        )
+                if "0/1" not in header_before:
+                    errors.append(
+                        f"header missing '0/1' count: {header_before!r}"
+                    )
 
-                    # Mutate state.json — backstop interval (or watcher
-                    # event) should drive an ItemStatusChanged through to
-                    # the rail.
-                    _write_state(plans_dir, "done")
-                    await pilot.pause(3.0)
-
-                    glyphs_after = rail.glyphs_plain()
-                    results["rail_glyphs_after_mutation"] = glyphs_after
-                    if len(glyphs_after) != 1:
-                        errors.append(
-                            f"after mutation glyph count={len(glyphs_after)}, "
-                            f"expected 1"
-                        )
-                    elif glyphs_after[0] != STATUS_GLYPHS["done"]:
-                        errors.append(
-                            f"after mutation glyph={glyphs_after[0]!r}, "
-                            f"expected done {STATUS_GLYPHS['done']!r}"
-                        )
+                # Mutate state.json — backstop interval (or watcher event)
+                # should drive an ItemStatusChanged through to the header.
+                _write_state(plans_dir, "done")
+                await pilot.pause(3.0)
+                header_after = tab.header_text()
+                results["header_after_mutation"] = header_after
+                if "1/1" not in header_after:
+                    errors.append(
+                        f"after mutation header missing '1/1': "
+                        f"{header_after!r}"
+                    )
 
     asyncio.run(_run())
 


### PR DESCRIPTION
## Summary
- Plan-execution tab now reaches terminal state correctly. Reads `finalReview.result` (was the phantom `verdict`), and also flips terminal on `state.status ∈ {completed,failed,aborted}` so engine bailouts surface too.
- Header redesigned: one tidy line with a clear status badge (`✓ Completed (SHIP)`, `✗ Completed (REVISE)`, `✗ Failed`, `⊘ Aborted`, lowercase phase while live), single count, inline PR # / elapsed on terminal. Bottom `PlanStatusRail` removed — its info was duplicated by the dep graph and the new badge.
- New compact `PlanProgress` gauge (renamed from `PlanDonut`) sits in the top-right: 12-cell coloured bar above, `done/total <pct>%` below.
- New header buttons:
  - `→ PR` — opens the in-TUI PR view via `acp_messages.OpenPanel("prs", filters={title: slug})`, reusing the same path the agent uses.
  - `✕` — closes the tab. Live runs trigger a confirmation modal explaining the orchestrator keeps running and the agent can reopen the view on request.
- Prompt input fixes: alt+enter newline (works on stock Terminal.app/iTerm2 via a small Textual xterm-parser patch in `src/toad/_textual_key_patch.py`), enter always sends, no more mode-flip dead-key state.
- Repo docs added: `docs/dev-state-schema.md` (engine ↔ TUI contract + open gaps) and `docs/dev-textual-quirks.md` (workarounds with removal criteria). Open follow-ups parked in `docs/plan-tab-followups.md`.
- Test cleanup: 6 pre-existing failures in `test_plan_execution_section` and `test_project_state_pane_orch` fixed by extending `_StubModel` to satisfy the full `PlanExecutionModel` protocol. Gantt and canon_sections suites still fail against current render APIs — deferred to a focused PR.

## Engine-side prereq (in `claude-code-config`)
The PR # / URL only render once `scripts/orch-engine.sh` persists `finalReview.prUrl` and `finalReview.prNumber` into `state.json` on ship. Spec: `claude-code-config/docs/specs/canon-tui-plan-completion.md`. Without it, the panel still completes — it just doesn't show the PR link.

## Test plan
- [ ] `uv run pytest tests/data/test_plan_execution_model.py tests/widgets/ -q` passes
- [ ] `uv run python tools/verify-tui.py` passes
- [ ] `bash install.sh --reinstall` then `canon --version` shows 0.7.7
- [ ] Open a real plan with the orchestrator; watch the panel reach Completed with PR # and elapsed inline
- [ ] Click `→ PR` — Planning > Board opens with the title filter applied
- [ ] Click `✕` on a running plan — modal appears; cancel keeps the tab; confirm closes it
- [ ] Press option+enter in the prompt — newline inserts; plain enter still sends

🤖 Generated with [Claude Code](https://claude.com/claude-code)