### PR TITLE
fix: read core's "ts" field for builder log timestamps (0.7.16)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canon-tui"
-version = "0.7.16"
+version = "0.7.17"
 description = "Canon TUI — a unified experience for AI in your terminal."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canon-tui"
-version = "0.7.15"
+version = "0.7.16"
 description = "Canon TUI — a unified experience for AI in your terminal."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/src/toad/widgets/builder_view.py
+++ b/src/toad/widgets/builder_view.py
@@ -98,24 +98,20 @@ def _render_log(entry: LogEntry, *, now: datetime | None = None) -> str:
 def _format_friendly_timestamp(
     raw: str, *, now: datetime | None = None
 ) -> str:
-    """Convert an ISO timestamp into a human-friendly relative/clock label."""
+    """Convert an ISO timestamp into a clock-time label (HH:MM:SS).
+
+    Relative labels ("12s ago", "just now") feel stale because they only
+    update when fresh state arrives, not as wall-clock time advances. For
+    now show absolute local time so the column doesn't lie. The signature
+    keeps ``now`` for tests / a future relative-time variant.
+    """
+    del now  # absolute time mode — no relative window
     if not raw:
         return ""
     parsed = _parse_iso(raw)
     if parsed is None:
-        # Last-resort: trim long timestamps to HH:MM:SS so the column stays narrow.
         return raw[-8:] if len(raw) >= 8 else raw
-    current = now or datetime.now(timezone.utc)
-    delta = (current - parsed).total_seconds()
-    if delta < 5:
-        return "just now"
-    if delta < 60:
-        return f"{int(delta)}s ago"
-    if delta < 3600:
-        return f"{int(delta // 60)}m ago"
-    if delta < 86400:
-        return parsed.astimezone().strftime("%H:%M")
-    return parsed.astimezone().strftime("%b %d %H:%M")
+    return parsed.astimezone().strftime("%H:%M:%S")
 
 
 def _parse_iso(raw: str) -> datetime | None:

--- a/src/toad/widgets/canon_state.py
+++ b/src/toad/widgets/canon_state.py
@@ -85,7 +85,9 @@ def _parse_state(
         LogEntry(
             level=entry.get("level", "info"),
             message=entry.get("msg", entry.get("message", "")),
-            timestamp=entry.get("timestamp", ""),
+            # Core writes "ts"; older fixtures used "timestamp". Accept either
+            # so the State view shows friendly relative times either way.
+            timestamp=entry.get("ts") or entry.get("timestamp") or "",
         )
         for entry in logs_raw
     )


### PR DESCRIPTION
## Summary
Mirror of #45 onto the `canon` branch so legacy `/apply-canon-tui` configs that pull from `canon` also pick up the timestamp fix.

Friendly timestamps shipped in 0.7.8 but never rendered in real runs — core writes the log timestamp under `ts`, while the TUI parser was reading `timestamp`. Same field-name drift class of bug as the earlier `finalReview.verdict` / `.result` mismatch.

## Test plan
- [ ] `canon update --branch canon` (or apply-canon-tui) → 0.7.16
- [ ] Open a project with `.canon/state.json` containing logs that use `ts`
- [ ] State view → log lines show timestamps in the leftmost column

🤖 Generated with [Claude Code](https://claude.com/claude-code)