### PR TITLE
plan tab: stream worker conversations from engine logs

### DIFF
--- a/src/toad/data/plan_execution_model.py
+++ b/src/toad/data/plan_execution_model.py
@@ -1,8 +1,10 @@
 """PlanExecutionModel — watch an orchestrator plan directory.
 
-Reads ``.orchestrator/plans/<slug>/state.json`` plus per-item
-``logs/<id>.log`` files and posts the Textual messages the existing
-plan-execution widgets already handle:
+Reads ``.orchestrator/plans/<slug>/state.json`` plus per-item worker
+log files (``logs/worker-<id>.log`` written by the orchestrator engine
+via ``tmux pipe-pane``; ``logs/<id>.log`` is honoured as a legacy
+fallback) and posts the Textual messages the existing plan-execution
+widgets already handle:
 
 - :class:`toad.widgets.plan_execution_tab.PlanExecutionTab.ItemStatusChanged`
   whenever an item's ``status`` field flips,
@@ -104,6 +106,7 @@ class PlanExecutionModel:
         self._started: bool = False
 
         self._log_positions: dict[int, int] = {}
+        self._log_paths: dict[int, Path] = {}
         self._log_subscribers: dict[int, list[Callable[[str], None]]] = {}
 
         self._initial_parse()
@@ -356,9 +359,16 @@ class PlanExecutionModel:
         with self._lock:
             ids = list(self._log_subscribers.keys())
         for item_id in ids:
-            log_path = self._plan_dir / "logs" / f"{item_id}.log"
-            if not log_path.exists():
+            log_path = self._resolve_log_path(item_id)
+            if log_path is None:
                 continue
+            previous_path = self._log_paths.get(item_id)
+            if previous_path is not None and previous_path != log_path:
+                # Engine started writing a richer file (e.g. worker-<id>.log
+                # superseded a legacy <id>.log); restart from byte 0 so we
+                # don't skip over the prefix of the new file.
+                self._log_positions[item_id] = 0
+            self._log_paths[item_id] = log_path
             pos = self._log_positions.get(item_id, 0)
             try:
                 size = log_path.stat().st_size
@@ -380,6 +390,25 @@ class PlanExecutionModel:
                 callbacks = list(self._log_subscribers.get(item_id, ()))
             for cb in callbacks:
                 cb(chunk)
+
+    def _resolve_log_path(self, item_id: int) -> Path | None:
+        """Locate the log file for ``item_id``.
+
+        The orchestrator engine pipes each worker's tmux pane to
+        ``logs/worker-<id>.log`` (and emits a final summary line to the
+        same file on exit). Older runs and tests use the bare
+        ``logs/<id>.log`` form. Prefer the engine's path; fall back to
+        the legacy one so test fixtures and any pre-existing plans keep
+        working.
+        """
+        logs_dir = self._plan_dir / "logs"
+        worker_path = logs_dir / f"worker-{item_id}.log"
+        if worker_path.exists():
+            return worker_path
+        legacy_path = logs_dir / f"{item_id}.log"
+        if legacy_path.exists():
+            return legacy_path
+        return None
 
     def _read_state(self) -> dict[str, Any] | None:
         path = self._plan_dir / "state.json"

--- a/src/toad/widgets/plan_worker_log_pane.py
+++ b/src/toad/widgets/plan_worker_log_pane.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Protocol, runtime_checkable
 
+from rich.text import Text
 from textual.message import Message
 from textual.widgets import RichLog
 
@@ -123,7 +124,13 @@ class PlanWorkerLogPane(RichLog):
         if event.item_id != self._item_id:
             return
         self._appended.append(event.text)
-        self.write(event.text)
+        # Worker logs come straight from `tmux pipe-pane` and contain raw
+        # ANSI escape codes (cursor moves, colour, terminal-mode toggles).
+        # `Text.from_ansi` parses the colour bits Rich understands and
+        # discards the unrenderable terminal-control sequences so the pane
+        # shows readable conversation instead of literal `[?1006l`-style
+        # garbage.
+        self.write(Text.from_ansi(event.text))
 
     # ------------------------------------------------------------------
     # Internals

--- a/tests/data/test_plan_execution_model.py
+++ b/tests/data/test_plan_execution_model.py
@@ -264,6 +264,60 @@ class TestItemLogAppended:
         assert "before unsub" in joined
         assert "after unsub" not in joined
 
+    def test_subscriber_reads_engine_worker_log(self, plan_dir: Path) -> None:
+        """The orchestrator engine pipes the worker tmux pane to
+        ``logs/worker-<id>.log``; the model must tail that file rather
+        than the legacy ``logs/<id>.log`` path so the worker pane shows
+        the live agent conversation, not just the final summary line.
+        """
+        target = _Recorder()
+        model = PlanExecutionModel(plan_dir, target=target, poll=True)
+        received: list[str] = []
+        unsubscribe = model.subscribe_log(1, received.append)
+        model.start()
+        try:
+            log_path = plan_dir / "logs" / "worker-1.log"
+            log_path.write_text("agent: thinking…\n", encoding="utf-8")
+            model.poll_now()
+            with log_path.open("a", encoding="utf-8") as fh:
+                fh.write("tool_use: Read(plan.md)\n")
+            model.poll_now()
+        finally:
+            unsubscribe()
+            model.stop()
+
+        joined = "".join(received)
+        assert "thinking" in joined
+        assert "Read(plan.md)" in joined
+
+    def test_worker_log_supersedes_legacy_path(self, plan_dir: Path) -> None:
+        """If a legacy ``logs/<id>.log`` was created first and the engine
+        later writes ``logs/worker-<id>.log``, the model switches to the
+        engine file from byte 0 — we must not skip the prefix of the new
+        file because of bytes already consumed from the legacy one.
+        """
+        target = _Recorder()
+        model = PlanExecutionModel(plan_dir, target=target, poll=True)
+        received: list[str] = []
+        unsubscribe = model.subscribe_log(1, received.append)
+        model.start()
+        try:
+            (plan_dir / "logs" / "1.log").write_text(
+                "legacy summary\n", encoding="utf-8"
+            )
+            model.poll_now()
+            (plan_dir / "logs" / "worker-1.log").write_text(
+                "fresh worker output\n", encoding="utf-8"
+            )
+            model.poll_now()
+        finally:
+            unsubscribe()
+            model.stop()
+
+        joined = "".join(received)
+        assert "legacy summary" in joined
+        assert "fresh worker output" in joined
+
     def test_log_pane_message_class_is_used(self, plan_dir: Path) -> None:
         """The log-append message class lives on ``PlanWorkerLogPane``.
 


### PR DESCRIPTION
## Summary

- Plan-execution model now tails `logs/worker-<id>.log` (the file the orch engine actually writes via `tmux pipe-pane`) with `logs/<id>.log` kept as a legacy fallback. Previously the pane stayed empty until the worker's exit summary line appeared.
- Resets the per-item byte position when the resolved path swaps mid-run so a legacy→worker filename change doesn't skip the new file's prefix.
- Worker log pane parses incoming chunks through `Text.from_ansi`, so tmux mode-toggle escapes render as colour (or get stripped) instead of as literal `[?1006l` garbage.

Background and option analysis: `docs/plan-worker-conversation-capture.md`.

## Test plan

- [x] `uv run pytest tests/data/test_plan_execution_model.py tests/widgets/test_plan_worker_log_pane.py -q` — 21 passed
- [x] `uv run ruff check` clean on touched files
- [x] `uv run python tools/verify-tui.py --widget imports` — pass
- [x] Smoke-tested against real `.orchestrator/plans/20260422-plan-execution-tab/` — model now surfaces the 526-byte `worker-1.log` (previously 0 bytes seen)
- [x] Faked progressive writes to a `worker-1.log` over 5 poll cycles → 5 chunks streamed in order
- [x] ANSI smoke test — green colour preserved, `\x1b[?1006l`-style toggles stripped from rendered output

## Follow-up (out of repo)

To make the conversation rich (not just the summary line), `dega_agent_headless_flags` in `claude-code-config` needs `--output-format stream-json --verbose` for `claude`. Once that lands the plan tab will stream tool calls and thinking with no further TUI work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)