### PR TITLE
right-pane liveness: status badges, pulses, flashes + bypass default

### DIFF
--- a/.claude/skills/canon-panel-routing/SKILL.md
+++ b/.claude/skills/canon-panel-routing/SKILL.md
@@ -111,6 +111,7 @@ Map these to `open_panel` calls in the agent prompt:
 | "open the plan"               | `plan`         | —                                       |
 | "show me the files"           | `files`        | —                                       |
 | "open the timeline"           | `timeline`     | —                                       |
+| "show me the outreach"        | `outreach`     | —                                       |
 | "hide the right panel"        | —              | send `close_panel` with `project_state` |
 
 ## Debugging

--- a/docs/core-request-orchestrator-status-watchdog.md
+++ b/docs/core-request-orchestrator-status-watchdog.md
@@ -148,6 +148,33 @@ re-parsing of `engine.log`.
 
 ---
 
+---
+
+## Bonus — `/canon-start` should surface the State panel
+
+**Files:** `~/.claude/commands/canon-start.md` (Phase 1 — Initialize)
+
+The TUI's State section in the right pane is hidden by default. The
+user opens it via the toolbar or by asking the agent (``show me the
+state``). When they invoke ``/canon-start``, ``.canon/state.json``
+starts updating immediately but the panel stays hidden — confusing.
+
+Stay consistent with the existing ``show me X`` pattern (which is
+agent-driven, not state-watch): one-line addition near the top of
+``canon-start.md``, same idiom as the existing ``terminal-ui-write.sh``
+guards.
+
+```bash
+command -v canon-ctl >/dev/null && canon-ctl action "screen.show_state" || true
+```
+
+Why agent-side and not canon-tui auto-watch: every project with a
+stale ``.canon/state.json`` would auto-pop the State panel on every
+canon launch. Language-driven panel routing keeps the UI quiet by
+default and predictable.
+
+---
+
 ## Why I'm asking for this
 
 canon-tui can polish the right-pane visuals all day, but if the

--- a/docs/core-request-orchestrator-status-watchdog.md
+++ b/docs/core-request-orchestrator-status-watchdog.md
@@ -1,0 +1,156 @@
+# Core request: orchestrator status watchdog + richer per-item state
+
+**Repo:** `claude-code-config`
+**Files:** `scripts/orch-engine.sh`, `scripts/orch-state.sh`, `scripts/orch-run.sh`
+**Why this matters:** canon-tui's plan-execution panel reads `state.json` as truth. When the engine dies ungracefully the state file is stale, the panel shows `running` forever, users mistrust the panel and stop opening it. Fixing this restores the panel as a reliable live view.
+
+---
+
+## Bug — top-level `status` stays `"running"` after crash
+
+The engine writes `status: "failed"` only on graceful exit paths
+(orch-engine.sh:1009 et al.). Any of the following leaves the file
+claiming the run is alive when it isn't:
+
+- Operator hits `Ctrl-C` or kills the tmux session
+- tmux server dies / machine sleeps / network drops mid-`gh` call
+- Python OOM in a worker brings down the parent
+- A `set -e` failure in an unhandled branch
+
+There is a `lastHeartbeat` field, but no consumer of it. canon-tui has
+no signal it can use to declare the run dead — it shows whatever the
+file says.
+
+## Requested fixes (small, isolated, no schema break)
+
+### 1. EXIT/INT/TERM trap on engine
+
+In `orch-engine.sh`, install a trap near the top:
+
+```bash
+_on_engine_exit() {
+  local code=$?
+  if [[ "${code}" -ne 0 ]] && [[ "$(jq -r '.status' "${ORCH_STATE_FILE}")" == "running" ]]; then
+    local now
+    now="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    jq --arg now "${now}" --arg code "${code}" \
+       '.status = "failed"
+        | .updatedAt = $now
+        | .lastError = ("engine exited with code " + $code)
+        | .finalReview.status = (if .finalReview.status == "running" then "aborted" else .finalReview.status end)' \
+       "${ORCH_STATE_FILE}" >"${ORCH_STATE_FILE}.tmp" && mv "${ORCH_STATE_FILE}.tmp" "${ORCH_STATE_FILE}"
+  fi
+}
+trap _on_engine_exit EXIT INT TERM
+```
+
+This alone covers ~80% of the "stays running" cases.
+
+### 2. Heartbeat staleness watchdog
+
+A second process needs to flag plans whose engine is gone. Cheapest
+landing: a guard in `orch-run.sh` that runs once at startup and
+sweeps any preexisting `state.json` files:
+
+```bash
+# At the top of orch-run.sh, before spawning the engine:
+for sf in "${ORCH_PLANS_DIR}"/*/state.json; do
+  [[ -f "${sf}" ]] || continue
+  status=$(jq -r '.status // "unknown"' "${sf}")
+  [[ "${status}" == "running" ]] || continue
+  hb=$(jq -r '.lastHeartbeat // ""' "${sf}")
+  [[ -n "${hb}" ]] || continue
+  hb_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "${hb}" +%s 2>/dev/null || echo 0)
+  now_epoch=$(date -u +%s)
+  age=$((now_epoch - hb_epoch))
+  # If heartbeat older than 2 minutes, mark aborted.
+  if (( age > 120 )); then
+    jq --arg now "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+       '.status = "aborted"
+        | .updatedAt = $now
+        | .lastError = "heartbeat stale (process dead)"
+        | .finalReview.status = (if .finalReview.status == "running" then "aborted" else .finalReview.status end)' \
+       "${sf}" >"${sf}.tmp" && mv "${sf}.tmp" "${sf}"
+  fi
+done
+```
+
+(Optional: lift this into a helper in `orch-state.sh` so other entry
+points can reuse it — `orch_state_reap_stale`.)
+
+### 3. Per-item stale detection — flip status, not just return IDs
+
+`orch_detect_stale_workers` in `orch-state.sh` already finds items
+whose `worker-<id>.log` hasn't been touched. It returns IDs but
+doesn't mutate state. Make it set `.items[i].status = "aborted"` and
+`.items[i].lastResult = "stale-no-output"` for each ID found, so the
+TUI surfaces the per-item state without inferring it.
+
+---
+
+## Bonus — richer per-item state for liveness UX
+
+Lower priority. Each is independent.
+
+### a. `items[].phase` field
+
+Today an item has `status` (queued/ready/running/review/done/failed)
+but the TUI has to read other fields to know what *kind* of running
+it's doing. Emit one of `spawning`, `awaiting-review`, `verifying`,
+`reworking` so the panel can show a phase chip without inference.
+
+### b. Per-criterion `verify.results[]`
+
+Today verification posts a single rolled-up `verification.status` at
+the end. Emit one entry per completion criterion as it runs:
+
+```json
+{
+  "verify": {
+    "status": "running",
+    "results": [
+      {"id": 1, "cmd": "uv run ruff check", "status": "passed", "elapsedMs": 234},
+      {"id": 2, "cmd": "uv run pytest -q", "status": "running"}
+    ]
+  }
+}
+```
+
+Lets the panel render a live verification checklist instead of a
+single end-state badge.
+
+### c. `events[]` JSONL alongside `state.json`
+
+Append-only log: one line per orchestrator event.
+
+```jsonl
+{"ts":"2026-05-03T18:14:02Z","type":"item_promoted","id":3,"from":"queued","to":"ready"}
+{"ts":"2026-05-03T18:14:05Z","type":"worker_spawned","id":3,"window":"worker-3"}
+{"ts":"2026-05-03T18:15:22Z","type":"review_done","id":3,"verdict":"SHIP"}
+```
+
+canon-tui can stream this directly into a per-plan event-log panel
+(the screenshot's "Event log // pm-trader cli" style) with no
+re-parsing of `engine.log`.
+
+---
+
+## Verification (after changes land)
+
+1. Start a plan with `orch-run.sh`, kill the tmux session mid-run.
+2. Re-run `orch-run.sh` (or just open canon-tui and look at the
+   plan-execution panel) — `state.json` should show `status: failed`
+   or `aborted` within ~2 minutes of the kill.
+3. canon-tui's `PlanExecutionModel` already handles `failed` /
+   `aborted` correctly; no canon-tui changes required for (1)–(3).
+4. For (a)–(c), canon-tui will need additive changes (separate
+   issue) but they're purely additive — old plan files keep working.
+
+---
+
+## Why I'm asking for this
+
+canon-tui can polish the right-pane visuals all day, but if the
+underlying state lies, every "● LIVE" badge is a lie. The watchdog
+is the single highest-leverage core change for the live-feel of the
+plan-execution panel.

--- a/src/toad/data/agent_context.md
+++ b/src/toad/data/agent_context.md
@@ -20,6 +20,10 @@ canon-ctl action "screen.show_timeline"    # Timeline / Gantt tab
 canon-ctl action "screen.show_state"
 canon-ctl action "screen.hide_state"
 
+# Outreach section (DM prospects, outreach status)
+canon-ctl action "screen.show_outreach"
+canon-ctl action "screen.hide_outreach"
+
 # Toggle the entire right pane open/closed
 canon-ctl action "screen.toggle_project_state"
 
@@ -89,10 +93,12 @@ the work? Subagent. Otherwise: `run_in_background`.
 
 ## Behavior
 
-- **Two sections:** Planning (GitHub + Timeline tabs) and State.
-  Each section can be shown or hidden independently.
+- **Three sections:** Planning (GitHub + Timeline tabs), State, and
+  Outreach. Each section can be shown or hidden independently.
 - **`show_github` / `show_timeline`** open Planning and switch to that tab.
+- **`show_outreach`** opens the Outreach section (DM prospects and status).
 - **`hide_planning`** hides the entire Planning section (both tabs).
+- **`hide_outreach`** hides the Outreach section.
 - Multiple sections can be visible at once (they share height evenly).
   Hiding all sections auto-closes the pane.
 
@@ -101,7 +107,9 @@ the work? Subagent. Otherwise: `run_in_background`.
 - User asks about PRs, plans, or GitHub status → `show_github`
 - User asks about project timeline or schedule → `show_timeline`
 - User asks about project state, build progress → `show_state`
+- User asks about outreach, DMs, or prospects → `show_outreach`
 - User asks to hide planning/github/timeline → `hide_planning`
+- User asks to hide outreach → `hide_outreach`
 - User asks to hide state → `hide_state`
 - User asks to see or hide the project panel → `toggle_project_state`
 - After updating the timeline → `refresh_timeline`

--- a/src/toad/data/plan_execution_model.py
+++ b/src/toad/data/plan_execution_model.py
@@ -191,7 +191,33 @@ class PlanExecutionModel:
         that item's log file until a new subscription arrives.
         """
         with self._lock:
-            self._log_subscribers.setdefault(item_id, []).append(callback)
+            existing = self._log_subscribers.setdefault(item_id, [])
+            is_first_subscriber = len(existing) == 0
+            existing.append(callback)
+
+        # Replay whatever is already on disk so a fresh subscriber sees
+        # the worker's prior conversation rather than just future diffs.
+        # Without this, navigating away from an item and back wipes the
+        # pane (the widget clears on switch) and the model — which only
+        # tails new bytes — has nothing to re-deliver, so the user loses
+        # the entire run history mid-session and after the worker exits.
+        snapshot = self._read_log_snapshot(item_id)
+        if snapshot:
+            callback(snapshot)
+        if is_first_subscriber:
+            # When the previous subscriber detached, the worker may have
+            # kept writing — leaving ``_log_positions`` lagging behind
+            # the file size. Sync to the snapshot length so the next
+            # ``poll_now`` doesn't re-deliver bytes already in the
+            # snapshot above. Other subscribers, if any, share the same
+            # position, so we only do this on the first attach.
+            log_path = self._resolve_log_path(item_id)
+            if log_path is not None:
+                try:
+                    self._log_positions[item_id] = log_path.stat().st_size
+                    self._log_paths[item_id] = log_path
+                except OSError:
+                    pass
 
         def _unsubscribe() -> None:
             with self._lock:
@@ -390,6 +416,23 @@ class PlanExecutionModel:
                 callbacks = list(self._log_subscribers.get(item_id, ()))
             for cb in callbacks:
                 cb(chunk)
+
+    def _read_log_snapshot(self, item_id: int) -> str:
+        """Return the full current contents of ``item_id``'s log, or ``""``.
+
+        Used to backfill a freshly attached subscriber so it sees the
+        worker's history. Does **not** advance ``_log_positions`` —
+        existing subscribers continue tailing from wherever they left
+        off, and the next ``poll_now`` only delivers new bytes appended
+        after this snapshot.
+        """
+        log_path = self._resolve_log_path(item_id)
+        if log_path is None:
+            return ""
+        try:
+            return log_path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            return ""
 
     def _resolve_log_path(self, item_id: int) -> Path | None:
         """Locate the log file for ``item_id``.

--- a/src/toad/widgets/conversation.py
+++ b/src/toad/widgets/conversation.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from asyncio import Future
 import asyncio
+import os
 
 from contextlib import suppress
 from functools import partial
@@ -507,6 +508,14 @@ class Conversation(containers.Vertical):
 
         self._directory_changed = False
         self._directory_watcher: DirectoryWatcher | None = None
+
+        # Auto-switch to bypassPermissions on session start so the
+        # conductor doesn't prompt for every tool. Tracked so the
+        # auto-switch fires once per Conversation lifetime — if the
+        # user manually picks a different mode later, a subsequent
+        # ``SetModes`` event from the agent won't override their
+        # choice. Disable by setting CANON_NO_AUTO_BYPASS=1.
+        self._auto_bypass_applied: bool = False
 
         self._initial_prompt = initial_prompt
 
@@ -1319,6 +1328,33 @@ class Conversation(containers.Vertical):
     async def on_acp_set_modes(self, message: acp_messages.SetModes):
         self.modes = message.modes
         self.current_mode = self.modes[message.current_mode]
+        await self._maybe_apply_auto_bypass()
+
+    async def _maybe_apply_auto_bypass(self) -> None:
+        """Switch to ``bypassPermissions`` on session start.
+
+        Fires once per Conversation. Bails when:
+
+        - the agent doesn't expose ``bypassPermissions`` (e.g. the
+          adapter is running as root and ``claude-code-acp`` strips
+          the option), so non-Claude agents are unaffected;
+        - the user opted out via ``CANON_NO_AUTO_BYPASS=1``;
+        - the session already started in a non-default mode (a resumed
+          session keeps the user's prior choice).
+        """
+        if self._auto_bypass_applied:
+            return
+        if os.environ.get("CANON_NO_AUTO_BYPASS"):
+            self._auto_bypass_applied = True
+            return
+        if "bypassPermissions" not in (self.modes or {}):
+            return
+        current_id = self.current_mode.id if self.current_mode else None
+        if current_id and current_id != "default":
+            self._auto_bypass_applied = True
+            return
+        self._auto_bypass_applied = True
+        await self.set_mode("bypassPermissions")
 
     @on(messages.HistoryMove)
     async def on_history_move(self, message: messages.HistoryMove) -> None:

--- a/src/toad/widgets/outreach_cards.py
+++ b/src/toad/widgets/outreach_cards.py
@@ -35,6 +35,12 @@ _BAR_EMPTY: Final[str] = "░"
 _DOT_ACTIVE: Final[str] = "●"
 _DOT_IDLE: Final[str] = "○"
 
+# Tick-flash duration for numeric stat changes. Long enough to register,
+# short enough that a fast stream of updates doesn't strobe.
+_TICK_FLASH_SECONDS: Final[float] = 0.7
+_TICK_UP_STYLE: Final[str] = "bold bright_green"
+_TICK_DOWN_STYLE: Final[str] = "bold bright_red"
+
 
 def _style_for(name: str) -> str:
     return CANON_STYLES.get(name, name)
@@ -61,6 +67,12 @@ class _CardBase(Static):
     def __init__(self, **kwargs: object) -> None:
         super().__init__("", **kwargs)  # type: ignore[arg-type]
         self._rendered: Text = Text()
+        # Subclasses that show a primary numeric value flip this on each
+        # ``set_data`` to indicate "value just went up / just went down".
+        # ``_build()`` paints the value with the matching style; we clear
+        # it after ``_TICK_FLASH_SECONDS`` so the colour is transient.
+        self._tick_flash: str | None = None
+        self._tick_flash_timer: object | None = None
 
     @property
     def rendered(self) -> Text:
@@ -78,6 +90,31 @@ class _CardBase(Static):
 
     def render(self) -> Text:
         return self._rendered
+
+    def _set_tick_flash(self, *, old: int, new: int) -> None:
+        """Set the tick-flash colour based on the direction of change.
+
+        Called by subclass ``set_data`` methods. No-op when the value
+        is unchanged or this is the first set (old == 0 with new == 0
+        or initial-load semantics handled at the call site).
+        """
+        if new > old:
+            self._tick_flash = _TICK_UP_STYLE
+        elif new < old:
+            self._tick_flash = _TICK_DOWN_STYLE
+        else:
+            return
+        if self._tick_flash_timer is not None:
+            self._tick_flash_timer.stop()
+        if self.is_mounted:
+            self._tick_flash_timer = self.set_timer(
+                _TICK_FLASH_SECONDS, self._clear_tick_flash
+            )
+
+    def _clear_tick_flash(self) -> None:
+        self._tick_flash = None
+        self._tick_flash_timer = None
+        self._refresh_content()
 
 
 class StatLine(_CardBase):
@@ -108,6 +145,7 @@ class StatLine(_CardBase):
         total: int,
         segments: tuple[tuple[str, int, str], ...],
     ) -> None:
+        self._set_tick_flash(old=self._total, new=total)
         self._total = total
         self._segments = segments
         self._refresh_content()
@@ -116,7 +154,10 @@ class StatLine(_CardBase):
         text = Text()
         text.append(self._label, style=_style_for("primary"))
         text.append("  ")
-        text.append(_format_int(self._total), style=_style_for("accent"))
+        text.append(
+            _format_int(self._total),
+            style=self._tick_flash or _style_for("accent"),
+        )
         text.append("\n")
 
         total = max(self._total, 0)
@@ -169,6 +210,7 @@ class Histogram(_CardBase):
         self._rendered = self._build()
 
     def set_data(self, buckets: tuple[int, ...], total: int) -> None:
+        self._set_tick_flash(old=self._total, new=total)
         self._buckets = self._normalize(buckets)
         self._total = total
         self._refresh_content()
@@ -185,7 +227,10 @@ class Histogram(_CardBase):
         text = Text()
         text.append(self._label, style=_style_for("primary"))
         text.append("  ")
-        text.append(_format_int(self._total), style=_style_for("accent"))
+        text.append(
+            _format_int(self._total),
+            style=self._tick_flash or _style_for("accent"),
+        )
         text.append("\n")
 
         peak = max(self._buckets) if self._buckets else 0

--- a/src/toad/widgets/plan_execution_section.py
+++ b/src/toad/widgets/plan_execution_section.py
@@ -301,7 +301,13 @@ class PlanExecutionSection(Vertical):
         tabs = self.query_one("#plan-exec-tabs", TabbedContent)
         tabs.remove_pane(self._tab_id(slug))
         if not self._open_slugs:
+            # Closing the last plan tab: Textual leaves ``tabs.active``
+            # pointing at the just-removed tab id, so the freshly mounted
+            # empty pane never surfaces and the user sees a blank section
+            # ("I close with X and don't see the plans"). Re-add and
+            # explicitly activate the empty pane after the layout settles.
             tabs.add_pane(self._build_empty_pane(self._listed_plans))
+            self.call_after_refresh(self._activate, EMPTY_PANE_ID)
 
     # ------------------------------------------------------------------
     # Empty-state list — open / mark-crashed / remove buttons

--- a/src/toad/widgets/plan_execution_tab.py
+++ b/src/toad/widgets/plan_execution_tab.py
@@ -38,6 +38,7 @@ from toad.directory_watcher import DirectoryChanged, DirectoryWatcher
 from toad.widgets.plan_dep_graph import DepGraphItem, PlanDepGraph
 from toad.widgets.plan_progress import PlanProgress
 from toad.widgets.plan_worker_log_pane import PlanWorkerLogPane
+from toad.widgets.section_status_badge import BadgeState, SectionStatusBadge
 
 if TYPE_CHECKING:
     from toad.data.plan_execution_model import TerminalInfo
@@ -124,6 +125,7 @@ class PlanExecutionModel(Protocol):
     issue_number: int | None
     items: Sequence[DepGraphItem]
     verdict: str
+    phase: str
     plan_dir: Path
 
     def subscribe_log(
@@ -305,6 +307,11 @@ class PlanExecutionTab(TabPane):
                     self._compute_header_text(),
                     id="plan-exec-header-text",
                 )
+                yield SectionStatusBadge(
+                    self._badge_state_for_phase(),
+                    message=self._badge_message(),
+                    id="plan-exec-badge",
+                )
                 yield PlanProgress(
                     items=self._items,
                     id="plan-exec-donut",
@@ -335,6 +342,48 @@ class PlanExecutionTab(TabPane):
         """Return the current header string (handy for assertions)."""
         return self._compute_header_text()
 
+    # ------------------------------------------------------------------
+    # Status badge
+    # ------------------------------------------------------------------
+
+    # Phase strings come from PlanExecutionModel._derive_phase. They're
+    # stable enough to pin here — adding a new phase requires a deliberate
+    # mapping update, which is the point.
+    _PHASE_TO_STATE = {
+        "Running": BadgeState.LIVE,
+        "Review": BadgeState.UPDATING,
+        "Verify": BadgeState.UPDATING,
+        "Done": BadgeState.IDLE,
+        "Failed": BadgeState.ERROR,
+    }
+
+    def _badge_state_for_phase(self) -> BadgeState:
+        return self._PHASE_TO_STATE.get(self._model.phase, BadgeState.IDLE)
+
+    def _badge_message(self) -> str | None:
+        """Show the verdict on terminal phases, the phase label otherwise.
+
+        While the run is live, ``Running`` / ``Review`` / ``Verify`` is
+        the most informative thing to show; once the run is over, the
+        verdict (``SHIP`` / ``REVISE`` / ``FAILED``) is what the user
+        wants to see at a glance.
+        """
+        phase = self._model.phase
+        if phase in {"Done", "Failed"}:
+            verdict = (self._verdict or "").strip()
+            if verdict and verdict.lower() != "running":
+                return verdict
+        return phase or None
+
+    def _sync_badge(self, *, updated: bool = False) -> None:
+        try:
+            badge = self.query_one("#plan-exec-badge", SectionStatusBadge)
+        except Exception:
+            return
+        badge.set_state(self._badge_state_for_phase(), message=self._badge_message())
+        if updated:
+            badge.mark_updated()
+
     @property
     def selected_item_id(self) -> int | None:
         return self._selected_item_id
@@ -358,6 +407,7 @@ class PlanExecutionTab(TabPane):
         self.query_one(PlanDepGraph).set_items(self._items)
         self.query_one(PlanProgress).set_items(self._items)
         self._refresh_header()
+        self._sync_badge(updated=True)
 
     def on_plan_execution_tab_item_status_changed(
         self, event: ItemStatusChanged
@@ -375,6 +425,7 @@ class PlanExecutionTab(TabPane):
         self.query_one(PlanDepGraph).set_items(self._items)
         self.query_one(PlanProgress).set_items(self._items)
         self._refresh_header()
+        self._sync_badge(updated=True)
 
     def on_plan_execution_tab_plan_finished(self, event: PlanFinished) -> None:
         """Flip verdict on completion. Tab stays mounted."""
@@ -385,6 +436,7 @@ class PlanExecutionTab(TabPane):
         self.query_one(PlanProgress).set_items(self._items)
         self._refresh_pr_button()
         self._refresh_header()
+        self._sync_badge(updated=True)
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
         if event.button.id == "plan-exec-close-btn":

--- a/src/toad/widgets/plan_status_rail.py
+++ b/src/toad/widgets/plan_status_rail.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass
 from rich.text import Text
 from textual.message import Message
 from textual.reactive import reactive
+from textual.timer import Timer
 from textual.widgets import Static
 
 
@@ -54,6 +55,13 @@ VERDICT_COLORS: dict[str, str] = {
 _FALLBACK_COLOR = "white"
 _FALLBACK_GLYPH = "•"
 _VERDICT_SEPARATOR = "  "
+
+# A "running" glyph alternates between two characters every
+# ``_PULSE_INTERVAL`` seconds so the rail breathes — the canonical
+# static glyph (``◉``) is the "lit" frame; the off-frame uses ``◎`` so
+# the silhouette stays the same width but the centre clears.
+_RUNNING_PULSE_GLYPH = "◎"
+_PULSE_INTERVAL = 0.7
 
 
 @dataclass(frozen=True)
@@ -97,6 +105,8 @@ class PlanStatusRail(Static):
     ) -> None:
         super().__init__(name=name, id=id, classes=classes)
         self._items: list[RailItem] = list(items) if items else []
+        self._pulse_on: bool = True
+        self._pulse_timer: Timer | None = None
         self.set_reactive(PlanStatusRail.verdict, verdict)
 
     # ------------------------------------------------------------------
@@ -106,6 +116,7 @@ class PlanStatusRail(Static):
     def set_items(self, items: list[RailItem]) -> None:
         """Replace the rail's items and re-render."""
         self._items = list(items)
+        self._sync_pulse_timer()
         self.refresh()
 
     def set_verdict(self, verdict: str) -> None:
@@ -151,6 +162,7 @@ class PlanStatusRail(Static):
             return
         existing = self._items[position]
         self._items[position] = RailItem(id=existing.id, status=event.status)
+        self._sync_pulse_timer()
         self.refresh()
 
     # ------------------------------------------------------------------
@@ -164,8 +176,39 @@ class PlanStatusRail(Static):
         return self._build_label()
 
     # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def on_mount(self) -> None:
+        self._sync_pulse_timer()
+
+    def on_unmount(self) -> None:
+        if self._pulse_timer is not None:
+            self._pulse_timer.stop()
+            self._pulse_timer = None
+
+    # ------------------------------------------------------------------
     # Internals
     # ------------------------------------------------------------------
+
+    def _has_running_item(self) -> bool:
+        return any(item.status == "running" for item in self._items)
+
+    def _sync_pulse_timer(self) -> None:
+        """Start the pulse timer iff at least one item is currently
+        running. Idle plans don't waste a tick.
+        """
+        wants_pulse = self._has_running_item()
+        if wants_pulse and self._pulse_timer is None:
+            self._pulse_timer = self.set_interval(_PULSE_INTERVAL, self._toggle_pulse)
+        elif not wants_pulse and self._pulse_timer is not None:
+            self._pulse_timer.stop()
+            self._pulse_timer = None
+            self._pulse_on = True  # leave the canonical glyph showing
+
+    def _toggle_pulse(self) -> None:
+        self._pulse_on = not self._pulse_on
+        self.refresh()
 
     def _index_of(self, item_id: int) -> int | None:
         for index, item in enumerate(self._items):
@@ -176,7 +219,10 @@ class PlanStatusRail(Static):
     def _build_label(self) -> Text:
         label = Text()
         for index, item in enumerate(self._items):
-            glyph = STATUS_GLYPHS.get(item.status, _FALLBACK_GLYPH)
+            if item.status == "running" and not self._pulse_on:
+                glyph = _RUNNING_PULSE_GLYPH
+            else:
+                glyph = STATUS_GLYPHS.get(item.status, _FALLBACK_GLYPH)
             color = STATUS_COLORS.get(item.status, _FALLBACK_COLOR)
             if index > 0:
                 label.append(" ")

--- a/src/toad/widgets/plan_worker_log_pane.py
+++ b/src/toad/widgets/plan_worker_log_pane.py
@@ -20,6 +20,8 @@ from rich.text import Text
 from textual.message import Message
 from textual.widgets import RichLog
 
+from toad.widgets.worker_log_formatter import WorkerLogFormatter
+
 
 __all__ = [
     "ItemLogSubscriber",
@@ -81,6 +83,7 @@ class PlanWorkerLogPane(RichLog):
         self._item_id = item_id
         self._unsubscribe: Callable[[], None] | None = None
         self._appended: list[str] = []
+        self._formatter = WorkerLogFormatter()
 
     # ------------------------------------------------------------------
     # Public API
@@ -93,6 +96,7 @@ class PlanWorkerLogPane(RichLog):
         self._teardown_subscription()
         self.clear()
         self._appended.clear()
+        self._formatter = WorkerLogFormatter()
         self._item_id = item_id
         self._setup_subscription()
 
@@ -124,13 +128,16 @@ class PlanWorkerLogPane(RichLog):
         if event.item_id != self._item_id:
             return
         self._appended.append(event.text)
-        # Worker logs come straight from `tmux pipe-pane` and contain raw
-        # ANSI escape codes (cursor moves, colour, terminal-mode toggles).
-        # `Text.from_ansi` parses the colour bits Rich understands and
-        # discards the unrenderable terminal-control sequences so the pane
-        # shows readable conversation instead of literal `[?1006l`-style
-        # garbage.
-        self.write(Text.from_ansi(event.text))
+        # Worker logs are streamed through the formatter: NDJSON events
+        # from `claude --output-format stream-json --verbose` become
+        # one-line transcript entries (🔧/🤖/📄/✅), and anything that
+        # isn't JSON (legacy `-p` text output, engine-emitted lines like
+        # `--- worker N exited ---`, or partial tmux teardown ANSI) is
+        # passed through. `Text.from_ansi` strips the residual control
+        # sequences so they don't render as literal `[?1006l` garbage.
+        rendered = self._formatter.feed(event.text)
+        if rendered:
+            self.write(Text.from_ansi(rendered))
 
     # ------------------------------------------------------------------
     # Internals

--- a/src/toad/widgets/project_state_pane.py
+++ b/src/toad/widgets/project_state_pane.py
@@ -41,6 +41,7 @@ from toad.widgets.outreach_cards import AccountDot, Histogram, RankedBar, StatLi
 from toad.widgets.plan import Plan
 from toad.widgets.plan_execution_section import ModelFactory, PlanExecutionSection
 from toad.widgets.project_directory_tree import ProjectDirectoryTree
+from toad.widgets.section_status_badge import BadgeState, SectionStatusBadge
 from toad.widgets.subagent_tab_section import AgentFactory, SubagentTabSection
 from toad.widgets.task_detail import TaskDetail
 from toad.widgets.task_table import TaskTable
@@ -74,12 +75,26 @@ def _read_timeline_config(
     return None
 
 
-# Section IDs — used as TabbedContent widget IDs and toolbar button suffix
+# Section IDs — identify the wrapper container (Vertical) for each
+# section so toggling display on the section also hides its status
+# badge. The inner ``TabbedContent`` gets a separate ``tabs-<name>``
+# id so event selectors (``@on(TabbedContent.TabActivated, …)``) still
+# fire on the right widget.
 SECTION_CONTEXT = "section-context"
 SECTION_PLANNING = "section-planning"
 SECTION_STATE = "section-state"
 SECTION_OUTREACH = "section-outreach"
 SECTION_SUBAGENTS = SubagentTabSection.SECTION_ID
+
+TABS_CONTEXT = "tabs-context"
+TABS_PLANNING = "tabs-planning"
+TABS_STATE = "tabs-state"
+TABS_OUTREACH = "tabs-outreach"
+
+BADGE_CONTEXT = "badge-context"
+BADGE_PLANNING = "badge-planning"
+BADGE_STATE = "badge-state"
+BADGE_OUTREACH = "badge-outreach"
 
 OUTREACH_REFRESH_INTERVAL = 30
 
@@ -211,6 +226,13 @@ class ProjectStatePane(Vertical):
         height: 1fr;
     }
 
+    ProjectStatePane .section-badge {
+        dock: top;
+        height: 1;
+        padding: 0 1;
+        background: $surface 30%;
+    }
+
     ProjectStatePane TabPane {
         padding: 0 1;
     }
@@ -322,38 +344,48 @@ class ProjectStatePane(Vertical):
             )
 
         # --- Context section (plan + files) ---
-        with TabbedContent(id=SECTION_CONTEXT, classes="pane-section"):
-            with TabPane("Plan", id="tab-plan"):
-                yield Plan([], id="pane-plan")
-            with TabPane("Files", id="tab-files"):
-                yield ProjectDirectoryTree(
-                    self._project_path,
-                    id="project_directory_tree",
-                )
+        with Vertical(id=SECTION_CONTEXT, classes="pane-section"):
+            yield SectionStatusBadge(
+                BadgeState.IDLE, id=BADGE_CONTEXT, classes="section-badge"
+            )
+            with TabbedContent(id=TABS_CONTEXT):
+                with TabPane("Plan", id="tab-plan"):
+                    yield Plan([], id="pane-plan")
+                with TabPane("Files", id="tab-files"):
+                    yield ProjectDirectoryTree(
+                        self._project_path,
+                        id="project_directory_tree",
+                    )
 
         # --- Planning section: Board / Timeline.
         # Plans and PRs are now chip filters on the Board, not separate tabs.
-        with TabbedContent(id=SECTION_PLANNING, classes="pane-section"):
-            with TabPane("Board", id="tab-tasks"):
-                with ContentSwitcher(initial="tasks-list-view", id="tasks-switcher"):
-                    with Vertical(id="tasks-list-view"):
-                        yield FilterToolbar(id="task-filter-toolbar")
-                        yield Static("", id="tasks-status")
-                        yield TaskTable(id="task-table")
-                    with Vertical(id="tasks-detail-view"):
-                        with Horizontal(id="tasks-breadcrumb"):
-                            yield Button(
-                                "← Back",
-                                id="tasks-back-btn",
-                                tooltip="Return to the task list (Esc)",
-                            )
-                            yield Static(
-                                "",
-                                id="tasks-breadcrumb-label",
-                            )
-                        yield TaskDetail(id="task-detail")
-            with TabPane("Timeline", id="tab-timeline"):
-                yield GanttTimeline(id="pane-gantt")
+        with Vertical(id=SECTION_PLANNING, classes="pane-section"):
+            yield SectionStatusBadge(
+                BadgeState.POLLING, id=BADGE_PLANNING, classes="section-badge"
+            )
+            with TabbedContent(id=TABS_PLANNING):
+                with TabPane("Board", id="tab-tasks"):
+                    with ContentSwitcher(
+                        initial="tasks-list-view", id="tasks-switcher"
+                    ):
+                        with Vertical(id="tasks-list-view"):
+                            yield FilterToolbar(id="task-filter-toolbar")
+                            yield Static("", id="tasks-status")
+                            yield TaskTable(id="task-table")
+                        with Vertical(id="tasks-detail-view"):
+                            with Horizontal(id="tasks-breadcrumb"):
+                                yield Button(
+                                    "← Back",
+                                    id="tasks-back-btn",
+                                    tooltip="Return to the task list (Esc)",
+                                )
+                                yield Static(
+                                    "",
+                                    id="tasks-breadcrumb-label",
+                                )
+                            yield TaskDetail(id="task-detail")
+                with TabPane("Timeline", id="tab-timeline"):
+                    yield GanttTimeline(id="pane-gantt")
 
         # Canon state watcher (invisible, drives State view)
         yield CanonStateWidget(
@@ -370,21 +402,29 @@ class ProjectStatePane(Vertical):
         )
 
         # --- State section (canon build + run) ---
-        with TabbedContent(id=SECTION_STATE, classes="pane-section"):
-            with TabPane("State", id="tab-builder"):
-                yield BuilderView(id="builder-view")
+        with Vertical(id=SECTION_STATE, classes="pane-section"):
+            yield SectionStatusBadge(
+                BadgeState.LIVE, id=BADGE_STATE, classes="section-badge"
+            )
+            with TabbedContent(id=TABS_STATE):
+                with TabPane("State", id="tab-builder"):
+                    yield BuilderView(id="builder-view")
 
         # --- Outreach section (conditional) ---
         if self._outreach_provider is not None:
-            with TabbedContent(id=SECTION_OUTREACH, classes="pane-section"):
-                with TabPane("Outreach", id="tab-outreach"):
-                    with Vertical(id="outreach-container"):
-                        yield StatLine("Prospects", id="outreach-prospects")
-                        yield Histogram("Sends · 24h", id="outreach-sends")
-                        yield RankedBar(
-                            "Hackathons (top 5)", id="outreach-hackathons"
-                        )
-                        yield Vertical(id="outreach-accounts")
+            with Vertical(id=SECTION_OUTREACH, classes="pane-section"):
+                yield SectionStatusBadge(
+                    BadgeState.POLLING, id=BADGE_OUTREACH, classes="section-badge"
+                )
+                with TabbedContent(id=TABS_OUTREACH):
+                    with TabPane("Outreach", id="tab-outreach"):
+                        with Vertical(id="outreach-container"):
+                            yield StatLine("Prospects", id="outreach-prospects")
+                            yield Histogram("Sends · 24h", id="outreach-sends")
+                            yield RankedBar(
+                                "Hackathons (top 5)", id="outreach-hackathons"
+                            )
+                            yield Vertical(id="outreach-accounts")
 
     def on_mount(self) -> None:
         # All sections start hidden; the user opens one via toolbar / chat.
@@ -437,7 +477,7 @@ class ProjectStatePane(Vertical):
             self._outreach_timer.stop()
             self._outreach_timer = None
 
-    @on(TabbedContent.TabActivated, f"#{SECTION_PLANNING}")
+    @on(TabbedContent.TabActivated, f"#{TABS_PLANNING}")
     def _on_planning_tab_activated(
         self, event: TabbedContent.TabActivated
     ) -> None:
@@ -744,6 +784,33 @@ class ProjectStatePane(Vertical):
         log.warning("Tab %r not found in ProjectStatePane", tab_id)
 
     # ------------------------------------------------------------------
+    # Section status badges
+    # ------------------------------------------------------------------
+
+    def _mark_badge(
+        self,
+        badge_id: str,
+        *,
+        state: BadgeState | None = None,
+        message: str | None = None,
+        updated: bool = False,
+    ) -> None:
+        """Update a section's status badge.
+
+        ``updated=True`` calls ``mark_updated()`` so the relative
+        timestamp resets. Silent if the badge isn't mounted yet (early
+        refresh races) or doesn't exist (Outreach is conditional).
+        """
+        try:
+            badge = self.query_one(f"#{badge_id}", SectionStatusBadge)
+        except NoMatches:
+            return
+        if state is not None:
+            badge.set_state(state, message=message)
+        if updated:
+            badge.mark_updated()
+
+    # ------------------------------------------------------------------
     # Provider setup
     # ------------------------------------------------------------------
 
@@ -767,6 +834,7 @@ class ProjectStatePane(Vertical):
         """Fetch timeline via provider, transform, and update widget."""
         if self._provider is None:
             return
+        self._mark_badge(BADGE_PLANNING, state=BadgeState.UPDATING)
         try:
             milestones = await self._provider.fetch_milestones()
             items = await self._provider.fetch_items()
@@ -775,6 +843,11 @@ class ProjectStatePane(Vertical):
             gantt.timeline_data = timeline
         except Exception as exc:
             log.warning("Timeline fetch failed: %s", exc)
+            self._mark_badge(
+                BADGE_PLANNING, state=BadgeState.ERROR, message=str(exc)[:30]
+            )
+            return
+        self._mark_badge(BADGE_PLANNING, state=BadgeState.POLLING, updated=True)
 
     def refresh_timeline(self) -> None:
         """Re-fetch timeline data. Called via socket controller."""
@@ -789,14 +862,20 @@ class ProjectStatePane(Vertical):
         """Fetch an outreach snapshot and render it into the cards."""
         if self._outreach_provider is None:
             return
+        self._mark_badge(BADGE_OUTREACH, state=BadgeState.UPDATING)
         try:
             if not await self._outreach_provider.available():
+                self._mark_badge(BADGE_OUTREACH, state=BadgeState.OFFLINE)
                 return
             snapshot = await self._outreach_provider.snapshot()
         except Exception as exc:
             log.warning("Outreach fetch failed: %s", exc)
+            self._mark_badge(
+                BADGE_OUTREACH, state=BadgeState.ERROR, message=str(exc)[:30]
+            )
             return
         self._render_outreach(snapshot)
+        self._mark_badge(BADGE_OUTREACH, state=BadgeState.POLLING, updated=True)
 
     def _render_outreach(self, snapshot: OutreachSnapshot) -> None:
         """Push a snapshot into the 4 outreach cards."""
@@ -860,17 +939,23 @@ class ProjectStatePane(Vertical):
     async def _fetch_tasks(self) -> None:
         if self._task_provider is None:
             self._set_tasks_status("No task provider configured.", error=True)
+            self._mark_badge(BADGE_PLANNING, state=BadgeState.OFFLINE)
             return
         self._set_tasks_status("Loading tasks…")
+        self._mark_badge(BADGE_PLANNING, state=BadgeState.UPDATING)
         try:
             tasks = await self._task_provider.fetch_tasks()
         except Exception as exc:
             log.warning("Task fetch failed: %s", exc)
             self._set_tasks_status(f"Task fetch failed: {exc}", error=True)
+            self._mark_badge(
+                BADGE_PLANNING, state=BadgeState.ERROR, message=str(exc)[:30]
+            )
             return
         self._all_tasks = tasks
         self._sync_milestone_options(tasks)
         self._apply_filters()
+        self._mark_badge(BADGE_PLANNING, state=BadgeState.POLLING, updated=True)
 
     def _set_tasks_status(self, message: str, *, error: bool = False) -> None:
         """Update the inline status label above the table."""
@@ -1015,10 +1100,11 @@ class ProjectStatePane(Vertical):
 
     def _is_tasks_tab_active(self) -> bool:
         try:
-            tc = self.query_one(f"#{SECTION_PLANNING}", TabbedContent)
+            section = self.query_one(f"#{SECTION_PLANNING}")
+            tc = self.query_one(f"#{TABS_PLANNING}", TabbedContent)
         except NoMatches:
             return False
-        return tc.display and tc.active == "tab-tasks"
+        return section.display and tc.active == "tab-tasks"
 
     def action_refresh_tasks(self) -> None:
         if not self._is_tasks_tab_active():

--- a/src/toad/widgets/project_state_pane.py
+++ b/src/toad/widgets/project_state_pane.py
@@ -207,23 +207,52 @@ class ProjectStatePane(Vertical):
         padding: 1 2;
     }
 
+    /* Toolbar buttons styled as bracketed chips: less chrome, more
+       terminal. Active chip flips background to the surface 50% for a
+       quiet "selected" emphasis instead of a button-shaped affordance. */
     ProjectStatePane #pane-toolbar Button {
         min-width: 10;
         height: 1;
         margin: 0 1 0 0;
         border: none;
-        background: $surface;
+        background: transparent;
         color: $text-muted;
     }
 
+    ProjectStatePane #pane-toolbar Button:hover {
+        background: $surface 50%;
+        color: $text;
+    }
+
     ProjectStatePane #pane-toolbar Button.active {
-        background: $primary 30%;
+        background: $surface 60%;
         color: $text;
         text-style: bold;
     }
 
     ProjectStatePane .pane-section {
         height: 1fr;
+    }
+
+    /* Per-section accent ribbon. The badge dock sits above the
+       TabbedContent; we colour-tag each section by its left border so
+       the eye can locate Context / Planning / State / Outreach without
+       reading the labels. Colours match the SectionStatusBadge dot
+       palette: cyan / magenta / green / yellow. */
+    ProjectStatePane #section-context {
+        border-left: tall cyan 25%;
+    }
+    ProjectStatePane #section-planning {
+        border-left: tall magenta 25%;
+    }
+    ProjectStatePane #section-state {
+        border-left: tall green 25%;
+    }
+    ProjectStatePane #section-outreach {
+        border-left: tall orange 25%;
+    }
+    ProjectStatePane #section-plan-execution {
+        border-left: tall yellow 30%;
     }
 
     ProjectStatePane .section-badge {

--- a/src/toad/widgets/project_state_pane.py
+++ b/src/toad/widgets/project_state_pane.py
@@ -431,9 +431,14 @@ class ProjectStatePane(Vertical):
         )
 
         # --- State section (canon build + run) ---
+        # Badge uses POLLING (not LIVE) on purpose: "live" is overloaded
+        # in canon-land — it means "live trading vs paper" at the
+        # automation level. The section's own state badge talks about
+        # data freshness, not execution mode, so we use POLLING /
+        # UPDATING / IDLE / ERROR vocabulary.
         with Vertical(id=SECTION_STATE, classes="pane-section"):
             yield SectionStatusBadge(
-                BadgeState.LIVE, id=BADGE_STATE, classes="section-badge"
+                BadgeState.POLLING, id=BADGE_STATE, classes="section-badge"
             )
             with TabbedContent(id=TABS_STATE):
                 with TabPane("State", id="tab-builder"):

--- a/src/toad/widgets/section_status_badge.py
+++ b/src/toad/widgets/section_status_badge.py
@@ -1,0 +1,216 @@
+"""SectionStatusBadge — pulsing dot + state + relative-update label.
+
+A single-line live status pill for the right-pane sections. Renders as
+
+    ● LIVE   ·   3s ago
+
+with the dot pulsing every 800ms while the state is "live" or
+"updating", static otherwise. Owners (sections, panes, widgets) call
+:meth:`mark_updated` whenever the underlying data refreshes; the
+badge keeps its own timer to re-render the relative timestamp every
+second so "3s ago" stays honest without the owner having to do
+anything.
+
+The component is intentionally dumb about *what* refreshed — it only
+tracks "when was the last update?" and "what state should I claim?".
+Sections set the state once on mount (typically ``State.LIVE`` for
+streaming, ``State.POLLING`` for periodic, ``State.IDLE`` for
+inactive), then call ``mark_updated()`` from their existing refresh
+hooks.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from enum import Enum
+
+from rich.text import Text
+from textual.reactive import reactive
+from textual.timer import Timer
+from textual.widgets import Static
+
+
+__all__ = ["SectionStatusBadge", "BadgeState"]
+
+
+_PULSE_INTERVAL = 0.8
+_TICK_INTERVAL = 1.0
+
+
+class BadgeState(str, Enum):
+    """The badge has six well-known states.
+
+    Each state controls the dot colour and the verb shown after it.
+    Section owners pick the state that fits their refresh shape and
+    don't usually toggle between them at runtime — except for ``ERROR``
+    / ``IDLE`` overrides during failure or shutdown.
+    """
+
+    LIVE = "live"          # Streaming source — pulses
+    POLLING = "polling"    # Interval-driven refresh — pulses
+    UPDATING = "updating"  # One-off refresh in flight — pulses faster
+    IDLE = "idle"          # Source available but quiet — static
+    ERROR = "error"        # Refresh failed — static, red
+    OFFLINE = "offline"    # No source / disabled — static, dim
+
+
+_STATE_LABELS: dict[BadgeState, str] = {
+    BadgeState.LIVE: "LIVE",
+    BadgeState.POLLING: "POLLING",
+    BadgeState.UPDATING: "UPDATING",
+    BadgeState.IDLE: "IDLE",
+    BadgeState.ERROR: "ERROR",
+    BadgeState.OFFLINE: "OFFLINE",
+}
+
+_STATE_COLOURS: dict[BadgeState, str] = {
+    BadgeState.LIVE: "bright_green",
+    BadgeState.POLLING: "cyan",
+    BadgeState.UPDATING: "yellow",
+    BadgeState.IDLE: "grey50",
+    BadgeState.ERROR: "red",
+    BadgeState.OFFLINE: "grey30",
+}
+
+_PULSING_STATES = frozenset({BadgeState.LIVE, BadgeState.POLLING, BadgeState.UPDATING})
+
+
+class SectionStatusBadge(Static):
+    """Compact status pill for right-pane section headers.
+
+    Usage::
+
+        badge = SectionStatusBadge(BadgeState.POLLING)
+        # … later, from the section's refresh hook:
+        badge.mark_updated()
+        # … on permanent failure:
+        badge.set_state(BadgeState.ERROR, message="GH 401")
+    """
+
+    DEFAULT_CSS = """
+    SectionStatusBadge {
+        height: 1;
+        padding: 0 1;
+        color: $text-muted;
+    }
+    """
+
+    state: reactive[BadgeState] = reactive(BadgeState.IDLE, init=False)
+
+    def __init__(
+        self,
+        state: BadgeState = BadgeState.IDLE,
+        *,
+        message: str | None = None,
+        **kwargs,
+    ) -> None:
+        super().__init__(**kwargs)
+        self._last_update: datetime | None = None
+        self._message = message
+        self._pulse_on = True
+        self._pulse_timer: Timer | None = None
+        self._tick_timer: Timer | None = None
+        # Initial state goes through ``set_reactive`` so the watcher
+        # doesn't fire on construction (the widget isn't mounted yet
+        # and the pulse timer can't be created until it is).
+        self.set_reactive(SectionStatusBadge.state, state)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def mark_updated(self) -> None:
+        """Record that the underlying source just refreshed.
+
+        Resets the relative-time counter shown after the state label.
+        Does not change ``state`` — sections call this from their
+        existing refresh hooks; state transitions go through
+        :meth:`set_state`.
+        """
+        self._last_update = datetime.now(tz=timezone.utc)
+        self.refresh()
+
+    def set_state(self, state: BadgeState, *, message: str | None = None) -> None:
+        """Move to a new state, optionally with a one-line message.
+
+        ``message`` is appended after the state label (useful for
+        ``ERROR``: ``● ERROR  ·  GH 401``). Cleared by passing
+        ``message=None`` or by transitioning to a non-error state.
+        """
+        self._message = message
+        self.state = state
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def on_mount(self) -> None:
+        self._tick_timer = self.set_interval(_TICK_INTERVAL, self.refresh)
+        self._sync_pulse_timer()
+
+    def on_unmount(self) -> None:
+        if self._pulse_timer is not None:
+            self._pulse_timer.stop()
+            self._pulse_timer = None
+        if self._tick_timer is not None:
+            self._tick_timer.stop()
+            self._tick_timer = None
+
+    # ------------------------------------------------------------------
+    # Reactive watcher
+    # ------------------------------------------------------------------
+
+    def watch_state(self, _old: BadgeState, _new: BadgeState) -> None:
+        # The pulse timer only runs while the state pulses; flipping
+        # to/from a static state should add or drop it.
+        self._sync_pulse_timer()
+        self._pulse_on = True
+        self.refresh()
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _sync_pulse_timer(self) -> None:
+        wants_pulse = self.state in _PULSING_STATES
+        if wants_pulse and self._pulse_timer is None:
+            self._pulse_timer = self.set_interval(_PULSE_INTERVAL, self._toggle_pulse)
+        elif not wants_pulse and self._pulse_timer is not None:
+            self._pulse_timer.stop()
+            self._pulse_timer = None
+            self._pulse_on = True  # leave the dot lit when static
+
+    def _toggle_pulse(self) -> None:
+        self._pulse_on = not self._pulse_on
+        self.refresh()
+
+    def render(self) -> Text:
+        colour = _STATE_COLOURS[self.state]
+        dot_text = "●" if self._pulse_on else "○"
+        label = _STATE_LABELS[self.state]
+        text = Text()
+        text.append(dot_text, style=f"bold {colour}")
+        text.append(" ", style="")
+        text.append(label, style=f"bold {colour}")
+        if self._message:
+            text.append("  ·  ", style="dim")
+            text.append(self._message, style=colour)
+        if self._last_update is not None:
+            text.append("  ·  ", style="dim")
+            text.append(_relative_time(self._last_update), style="dim")
+        return text
+
+
+def _relative_time(when: datetime) -> str:
+    """Compact relative timestamp: ``3s ago``, ``2m ago``, ``1h ago``."""
+    now = datetime.now(tz=timezone.utc)
+    delta = (now - when).total_seconds()
+    if delta < 1:
+        return "just now"
+    if delta < 60:
+        return f"{int(delta)}s ago"
+    if delta < 3600:
+        return f"{int(delta // 60)}m ago"
+    if delta < 86400:
+        return f"{int(delta // 3600)}h ago"
+    return f"{int(delta // 86400)}d ago"

--- a/src/toad/widgets/task_table.py
+++ b/src/toad/widgets/task_table.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Any
 
+from rich.text import Text
 from textual.widgets import DataTable
 
 from toad.widgets.github_views.task_provider import TaskItem
@@ -164,12 +165,22 @@ class TaskTable(DataTable[str]):
     }
     """
 
+    # Cells whose value changed between two ``set_tasks`` calls render
+    # with this background style for ``_FLASH_SECONDS`` so the eye
+    # catches the diff. Tuned to be visible on both light and dark
+    # themes without screaming.
+    _FLASH_STYLE = "on rgb(60,60,20)"
+    _FLASH_SECONDS = 1.5
+
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(zebra_stripes=True, **kwargs)
         self.cursor_type = "row"
         self._tasks: dict[str, TaskItem] = {}
         self._task_order: list[str] = []
         self._column_set: str = "all"
+        self._previous_cells: dict[str, list[str]] = {}
+        self._flash_cells: set[tuple[str, int]] = set()
+        self._flash_timer: Any = None
 
     def set_column_set(self, name: str) -> None:
         """Switch the visible columns to ``COLUMN_SETS[name]`` and re-render."""
@@ -186,12 +197,33 @@ class TaskTable(DataTable[str]):
 
     def set_tasks(self, tasks: list[TaskItem]) -> None:
         """Replace all rows with ``tasks``. Row keys = ``task.id``."""
+        formatters = COLUMN_SETS[self._column_set]
+        new_cells = {t.id: [fmt(t) for _, fmt in formatters] for t in tasks}
+
+        # Flash only when we have a previous snapshot to diff against.
+        # The first ``set_tasks`` call after mount/column-switch
+        # populates the baseline silently — flashing every cell on
+        # initial load would be useless noise.
+        flash: set[tuple[str, int]] = set()
+        if self._previous_cells:
+            for task_id, cells in new_cells.items():
+                prev = self._previous_cells.get(task_id)
+                if prev is None:
+                    continue  # newly-added rows aren't a "change"
+                for col, (old, new) in enumerate(zip(prev, cells, strict=False)):
+                    if old != new:
+                        flash.add((task_id, col))
+
         self._tasks = {t.id: t for t in tasks}
         self._task_order = [t.id for t in tasks]
+        self._previous_cells = new_cells
+        self._flash_cells = flash
+
         if not self.columns:
             self.set_column_set(self._column_set)
             return
         self._rerender_rows()
+        self._schedule_flash_clear()
 
     def _rerender_rows(self) -> None:
         self.clear()
@@ -200,7 +232,31 @@ class TaskTable(DataTable[str]):
             task = self._tasks.get(task_id)
             if task is None:
                 continue
-            self.add_row(*(fmt(task) for _, fmt in formatters), key=task.id)
+            cells: list[Any] = []
+            for col, (_, fmt) in enumerate(formatters):
+                value = fmt(task)
+                if (task_id, col) in self._flash_cells:
+                    cells.append(Text(str(value), style=self._FLASH_STYLE))
+                else:
+                    cells.append(value)
+            self.add_row(*cells, key=task.id)
+
+    def _schedule_flash_clear(self) -> None:
+        if not self._flash_cells:
+            return
+        if self._flash_timer is not None:
+            self._flash_timer.stop()
+        self._flash_timer = self.set_timer(
+            self._FLASH_SECONDS, self._clear_flash
+        )
+
+    def _clear_flash(self) -> None:
+        if not self._flash_cells:
+            return
+        self._flash_cells.clear()
+        self._flash_timer = None
+        if self.columns:
+            self._rerender_rows()
 
     def get_task(self, task_id: str) -> TaskItem | None:
         """Return the ``TaskItem`` previously set for ``task_id``."""

--- a/src/toad/widgets/user_input.py
+++ b/src/toad/widgets/user_input.py
@@ -14,7 +14,7 @@ class UserInput(containers.HorizontalGroup):
 
     def compose(self) -> ComposeResult:
         yield NonSelectableLabel("❯", id="prompt")
-        yield Markdown(self.content, id="content")
+        yield Markdown(self.content.replace("\n", "  \n"), id="content")
 
     def get_block_menu(self) -> Iterable[MenuItem]:
         yield from ()

--- a/src/toad/widgets/worker_log_formatter.py
+++ b/src/toad/widgets/worker_log_formatter.py
@@ -1,0 +1,202 @@
+"""Format orchestrator worker logs for the plan-execution worker pane.
+
+The orchestrator engine pipes each worker's tmux pane to
+``logs/worker-<id>.log`` via ``tmux pipe-pane``. With the agent shim
+configured for ``--output-format stream-json --verbose`` (Claude),
+that file is one JSON event per line — system init, assistant
+messages, tool uses, tool results, the final result. With the older
+``-p`` text mode it's a single summary line plus tmux ANSI teardown.
+
+This module turns either form into a readable transcript. JSON events
+become one-line summaries (``🔧 Read(path)``, ``📄 result preview``,
+``🤖 assistant text``, ``✅ done``); anything that isn't valid JSON
+passes through unchanged so the formatter is safe to deploy before
+the shim flips, and stays useful for any non-streaming output (e.g.
+``echo`` lines from the engine wrapper).
+
+Chunks delivered by ``PlanExecutionModel`` are not line-aligned —
+they're raw byte ranges from the file. The :class:`WorkerLogFormatter`
+buffers a partial trailing line until the next chunk so we never split
+a JSON object across two formatted outputs.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+__all__ = ["WorkerLogFormatter"]
+
+
+_MAX_PREVIEW = 240
+
+
+class WorkerLogFormatter:
+    """Stateful, per-item formatter that converts raw log chunks to text.
+
+    Use one instance per worker-pane attachment. ``feed(chunk)`` accepts
+    arbitrary byte-aligned text and returns the rendered transcript
+    fragment ready to write to the ``RichLog``. ``flush()`` emits any
+    remaining unterminated line — call it when switching items so a
+    trailing partial line isn't lost.
+    """
+
+    def __init__(self) -> None:
+        self._buffer = ""
+
+    def feed(self, chunk: str) -> str:
+        self._buffer += chunk
+        out: list[str] = []
+        while "\n" in self._buffer:
+            line, self._buffer = self._buffer.split("\n", 1)
+            rendered = _format_line(line)
+            if rendered:
+                out.append(rendered)
+        if not out:
+            return ""
+        return "\n".join(out) + "\n"
+
+    def flush(self) -> str:
+        if not self._buffer:
+            return ""
+        line, self._buffer = self._buffer, ""
+        rendered = _format_line(line)
+        return f"{rendered}\n" if rendered else ""
+
+
+def _format_line(line: str) -> str | None:
+    """Render one log line. ``None`` means 'drop silently'."""
+    stripped = line.strip()
+    if not stripped:
+        return None
+    # JSON event lines start with `{` and end with `}` (full object on a line).
+    if stripped.startswith("{") and stripped.endswith("}"):
+        try:
+            event = json.loads(stripped)
+        except ValueError:
+            return line  # malformed — show raw so issues are visible
+        if isinstance(event, dict):
+            return _render_event(event)
+    return line  # plain text passes through unchanged
+
+
+def _render_event(event: dict[str, Any]) -> str | None:
+    event_type = event.get("type")
+    if event_type == "system":
+        if event.get("subtype") == "init":
+            model = event.get("model") or "claude"
+            return f"⚙ session start  ·  {model}"
+        return None
+    if event_type == "rate_limit_event":
+        return None
+    if event_type == "assistant":
+        return _render_assistant(event)
+    if event_type == "user":
+        return _render_user(event)
+    if event_type == "result":
+        return _render_result(event)
+    return None
+
+
+def _render_assistant(event: dict[str, Any]) -> str | None:
+    message = event.get("message")
+    if not isinstance(message, dict):
+        return None
+    parts: list[str] = []
+    for block in message.get("content", []) or []:
+        if not isinstance(block, dict):
+            continue
+        block_type = block.get("type")
+        if block_type == "text":
+            text = (block.get("text") or "").strip()
+            if text:
+                # Don't truncate — this is the actual assistant
+                # conversation the user wants to read in the pane.
+                parts.append(f"🤖 {text}")
+        elif block_type == "thinking":
+            text = (block.get("thinking") or "").strip()
+            if text:
+                parts.append(f"💭 {text}")
+        elif block_type == "tool_use":
+            name = block.get("name") or "?"
+            summary = _summarize_tool_input(block.get("input"))
+            parts.append(f"🔧 {name}({summary})")
+    return "\n".join(parts) if parts else None
+
+
+def _render_user(event: dict[str, Any]) -> str | None:
+    message = event.get("message")
+    if not isinstance(message, dict):
+        return None
+    for block in message.get("content", []) or []:
+        if not isinstance(block, dict):
+            continue
+        if block.get("type") != "tool_result":
+            continue
+        content = block.get("content")
+        text = _extract_tool_result_text(content)
+        if not text:
+            continue
+        prefix = "⚠" if block.get("is_error") else "📄"
+        return f"{prefix} {_truncate(text)}"
+    return None
+
+
+def _render_result(event: dict[str, Any]) -> str | None:
+    text = (event.get("result") or "").strip()
+    is_error = bool(event.get("is_error"))
+    icon = "❌" if is_error else "✅"
+    if not text:
+        text = "error" if is_error else "done"
+    # Don't truncate — the result is the agent's final, deliberate
+    # output (summary, plan reply, etc.) and it's what the user is most
+    # likely to want to read in full.
+    return f"{icon} {text}"
+
+
+def _extract_tool_result_text(content: Any) -> str:
+    if isinstance(content, str):
+        return content.strip()
+    if isinstance(content, list):
+        chunks: list[str] = []
+        for item in content:
+            if isinstance(item, dict) and item.get("type") == "text":
+                text = item.get("text")
+                if isinstance(text, str):
+                    chunks.append(text)
+        return " ".join(chunks).strip()
+    return ""
+
+
+def _summarize_tool_input(inp: Any) -> str:
+    """One-line preview of a tool's argument set.
+
+    Picks the highest-signal field per known tool (path for Read/Edit,
+    command for Bash, pattern for Grep, …) and falls back to a
+    truncated key=value list for unknown tools.
+    """
+    if not isinstance(inp, dict):
+        return _truncate(str(inp), 80)
+    for key in ("file_path", "path", "notebook_path"):
+        value = inp.get(key)
+        if isinstance(value, str) and value:
+            return value
+    command = inp.get("command")
+    if isinstance(command, str) and command:
+        return _truncate(command, 80)
+    for key in ("pattern", "query", "url"):
+        value = inp.get(key)
+        if isinstance(value, str) and value:
+            return _truncate(value, 80)
+    pairs = []
+    for key, value in list(inp.items())[:2]:
+        pairs.append(f"{key}={_truncate(str(value), 30)}")
+    return ", ".join(pairs) if pairs else ""
+
+
+def _truncate(text: str, limit: int = _MAX_PREVIEW) -> str:
+    text = text.replace("\n", " ").strip()
+    if len(text) <= limit:
+        return text
+    return text[: limit - 1] + "…"

--- a/tests/data/test_plan_execution_model.py
+++ b/tests/data/test_plan_execution_model.py
@@ -318,6 +318,50 @@ class TestItemLogAppended:
         assert "legacy summary" in joined
         assert "fresh worker output" in joined
 
+    def test_subscribe_replays_existing_log_content(self, plan_dir: Path) -> None:
+        """A fresh subscriber receives whatever is already on disk so
+        switching away from an item and coming back doesn't wipe the
+        worker pane. The on-disk log survives the navigation; the model
+        must replay it on attach.
+        """
+        target = _Recorder()
+        model = PlanExecutionModel(plan_dir, target=target, poll=True)
+        model.start()
+        log_path = plan_dir / "logs" / "worker-1.log"
+        log_path.write_text("history line 1\nhistory line 2\n", encoding="utf-8")
+
+        # First subscriber sees the existing file as a single replay chunk.
+        first: list[str] = []
+        unsubscribe_first = model.subscribe_log(1, first.append)
+        try:
+            assert "history line 1" in "".join(first)
+            assert "history line 2" in "".join(first)
+            # No extra delivery on poll because the snapshot synced position.
+            model.poll_now()
+            assert "".join(first).count("history line 1") == 1
+        finally:
+            unsubscribe_first()
+
+        # New writes while no subscriber.
+        with log_path.open("a", encoding="utf-8") as fh:
+            fh.write("offline append\n")
+
+        # Re-attach (simulates navigating away and back to the item).
+        second: list[str] = []
+        unsubscribe_second = model.subscribe_log(1, second.append)
+        try:
+            joined = "".join(second)
+            # Must see the full history *and* the offline append, exactly once.
+            assert "history line 1" in joined
+            assert "history line 2" in joined
+            assert joined.count("offline append") == 1
+            model.poll_now()
+            # Polling after the snapshot must not re-deliver the gap.
+            assert "".join(second).count("offline append") == 1
+        finally:
+            unsubscribe_second()
+            model.stop()
+
     def test_log_pane_message_class_is_used(self, plan_dir: Path) -> None:
         """The log-append message class lives on ``PlanWorkerLogPane``.
 

--- a/tests/test_task_widgets.py
+++ b/tests/test_task_widgets.py
@@ -296,6 +296,74 @@ async def test_row_selection_swaps_content_switcher(
         assert switcher.current == "detail"
 
 
+# ------------------------------------------------------------------
+# Diff-flash on changed rows
+# ------------------------------------------------------------------
+
+
+class _DiffFlashHarness(App[None]):
+    def __init__(self) -> None:
+        super().__init__()
+
+    def compose(self) -> ComposeResult:
+        yield TaskTable(id="tbl")
+
+
+@pytest.mark.asyncio
+async def test_diff_flash_marks_only_changed_cells(
+    sample_tasks: list[TaskItem],
+) -> None:
+    """Second ``set_tasks`` call flashes cells whose value changed.
+
+    The first call seeds the baseline silently — we don't want every
+    cell to flash on initial render. Mutating one task's status and
+    calling again should mark exactly that one (task_id, col_idx).
+    """
+    from dataclasses import replace
+
+    app = _DiffFlashHarness()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        tbl = app.query_one(TaskTable)
+        tbl.set_tasks(sample_tasks)
+        await pilot.pause()
+        assert tbl._flash_cells == set(), "first load must not flash"
+
+        # Flip the first task's status; everything else stays put.
+        mutated = [
+            replace(sample_tasks[0], status=ItemStatus.DONE),
+            sample_tasks[1],
+        ]
+        tbl.set_tasks(mutated)
+        await pilot.pause()
+        # Status is column 0 in the "all" set.
+        assert (sample_tasks[0].id, 0) in tbl._flash_cells
+        assert all(
+            cell[0] == sample_tasks[0].id for cell in tbl._flash_cells
+        ), "only task 101 should be flashing"
+
+
+@pytest.mark.asyncio
+async def test_diff_flash_clears_after_timeout(
+    sample_tasks: list[TaskItem],
+) -> None:
+    """Drive the clear directly to avoid sleeping for the timeout."""
+    from dataclasses import replace
+
+    app = _DiffFlashHarness()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        tbl = app.query_one(TaskTable)
+        tbl.set_tasks(sample_tasks)
+        await pilot.pause()
+        tbl.set_tasks([replace(sample_tasks[0], status=ItemStatus.DONE), sample_tasks[1]])
+        await pilot.pause()
+        assert tbl._flash_cells, "flash should be set after a diff"
+        tbl._clear_flash()
+        await pilot.pause()
+        assert tbl._flash_cells == set()
+
+
 class _DrillDownHarness(App[None]):
     """App that mounts a TaskDetail pre-populated with a task.
 

--- a/tests/widgets/test_outreach_cards.py
+++ b/tests/widgets/test_outreach_cards.py
@@ -110,6 +110,43 @@ class TestStatLine:
         assert "Prospects" in text
         assert "0" in text
 
+    @pytest.mark.asyncio
+    async def test_tick_flash_on_increase(self) -> None:
+        """Setting a higher total tags the stat with the up-flash style;
+        clearing the flash returns the value to the canonical accent.
+        """
+
+        def build() -> StatLine:
+            return StatLine(label="Prospects", total=10, segments=())
+
+        async with _mounted(build) as widget:
+            assert isinstance(widget, StatLine)
+            assert widget._tick_flash is None  # baseline
+            widget.set_data(total=15, segments=())
+            assert widget._tick_flash == "bold bright_green"
+            widget._clear_tick_flash()
+            assert widget._tick_flash is None
+
+    @pytest.mark.asyncio
+    async def test_tick_flash_on_decrease(self) -> None:
+        def build() -> StatLine:
+            return StatLine(label="Prospects", total=20, segments=())
+
+        async with _mounted(build) as widget:
+            assert isinstance(widget, StatLine)
+            widget.set_data(total=12, segments=())
+            assert widget._tick_flash == "bold bright_red"
+
+    @pytest.mark.asyncio
+    async def test_tick_flash_unchanged_value_no_flash(self) -> None:
+        def build() -> StatLine:
+            return StatLine(label="Prospects", total=20, segments=())
+
+        async with _mounted(build) as widget:
+            assert isinstance(widget, StatLine)
+            widget.set_data(total=20, segments=())
+            assert widget._tick_flash is None
+
 
 # ---------------------------------------------------------------------------
 # Histogram

--- a/tests/widgets/test_plan_execution_section.py
+++ b/tests/widgets/test_plan_execution_section.py
@@ -134,6 +134,25 @@ class TestEmptyState:
             assert _empty_state_statics(section)
 
     @pytest.mark.asyncio
+    async def test_empty_pane_is_active_after_closing_last_tab(self) -> None:
+        """Regression: Textual leaves ``tabs.active`` pointing at the
+        just-removed tab id, so the freshly mounted empty pane never
+        surfaces and the user sees a blank section. Closing the last
+        plan tab must explicitly activate the empty pane.
+        """
+        app = _Harness()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            section = app.query_one(PlanExecutionSection)
+            section.open_tab("alpha")
+            await pilot.pause()
+            section.close_tab("alpha")
+            await pilot.pause()
+            await pilot.pause()  # call_after_refresh fires here
+            tabs = section.query_one("#plan-exec-tabs", TabbedContent)
+            assert tabs.active == EMPTY_PANE_ID
+
+    @pytest.mark.asyncio
     async def test_placeholder_present_without_factory(self) -> None:
         app = _Harness(with_factory=False)
         async with app.run_test() as pilot:

--- a/tests/widgets/test_plan_execution_section.py
+++ b/tests/widgets/test_plan_execution_section.py
@@ -41,6 +41,7 @@ class _StubModel:
     issue_number: int | None = 7
     items: list[Any] = field(default_factory=list)
     verdict: str = "running"
+    phase: str = "Running"
     plan_dir: Path = field(
         default_factory=lambda: Path("/nonexistent-stub-plan")
     )

--- a/tests/widgets/test_plan_execution_tab.py
+++ b/tests/widgets/test_plan_execution_tab.py
@@ -56,6 +56,7 @@ class _FakeModel:
     issue_number: int | None = 42
     items: list[DepGraphItem] = field(default_factory=list)
     verdict: str = "running"
+    phase: str = "Running"
     plan_dir: Path = field(default_factory=lambda: Path("/nonexistent-fake-plan"))
     subscriptions: list[_Subscription] = field(default_factory=list)
 
@@ -228,6 +229,90 @@ class TestPlanFinishedPersists:
             # Still mounted inside the TabbedContent.
             tabs = app.query_one(TabbedContent)
             assert tab.id in {pane.id for pane in tabs.query(PlanExecutionTab)}
+
+
+# ------------------------------------------------------------------
+# Status badge
+# ------------------------------------------------------------------
+
+
+class TestStatusBadge:
+    """The plan-exec badge mirrors the model's ``phase`` value.
+
+    ``Running`` → LIVE (pulsing), ``Review``/``Verify`` → UPDATING,
+    ``Done`` → IDLE with the verdict as the message, ``Failed`` →
+    ERROR. Any other phase falls back to IDLE.
+    """
+
+    @pytest.mark.asyncio
+    async def test_running_phase_is_live(self) -> None:
+        from toad.widgets.section_status_badge import (
+            BadgeState,
+            SectionStatusBadge,
+        )
+
+        model = _FakeModel(items=_fixture_items(), phase="Running")
+        app = _Harness(model)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            badge = app.query_one("#plan-exec-badge", SectionStatusBadge)
+            assert badge.state == BadgeState.LIVE
+
+    @pytest.mark.asyncio
+    async def test_done_phase_shows_verdict(self) -> None:
+        from toad.widgets.section_status_badge import (
+            BadgeState,
+            SectionStatusBadge,
+        )
+
+        model = _FakeModel(
+            items=_fixture_items(), phase="Done", verdict="SHIP"
+        )
+        app = _Harness(model)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            badge = app.query_one("#plan-exec-badge", SectionStatusBadge)
+            assert badge.state == BadgeState.IDLE
+            assert "SHIP" in badge.render().plain
+
+    @pytest.mark.asyncio
+    async def test_failed_phase_is_error(self) -> None:
+        from toad.widgets.section_status_badge import (
+            BadgeState,
+            SectionStatusBadge,
+        )
+
+        model = _FakeModel(items=_fixture_items(), phase="Failed")
+        app = _Harness(model)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            badge = app.query_one("#plan-exec-badge", SectionStatusBadge)
+            assert badge.state == BadgeState.ERROR
+
+    @pytest.mark.asyncio
+    async def test_phase_change_propagates_through_handler(self) -> None:
+        """Updating the model's phase and posting an item-status-changed
+        event re-syncs the badge — the tab re-reads ``model.phase`` from
+        every status flip handler so phase shifts during a run land
+        without bespoke wiring.
+        """
+        from toad.widgets.section_status_badge import (
+            BadgeState,
+            SectionStatusBadge,
+        )
+
+        model = _FakeModel(items=_fixture_items(), phase="Running")
+        app = _Harness(model)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            tab = app.query_one(PlanExecutionTab)
+            badge = app.query_one("#plan-exec-badge", SectionStatusBadge)
+            assert badge.state == BadgeState.LIVE
+
+            model.phase = "Review"
+            tab.post_message(PlanExecutionTab.ItemStatusChanged(2, "review"))
+            await pilot.pause()
+            assert badge.state == BadgeState.UPDATING
 
 
 # ------------------------------------------------------------------

--- a/tests/widgets/test_plan_status_rail.py
+++ b/tests/widgets/test_plan_status_rail.py
@@ -191,3 +191,64 @@ class TestItemStatusChanged:
             rail.post_message(PlanStatusRail.ItemStatusChanged(999, "done"))
             await pilot.pause()
             assert rail.glyphs_plain() == before
+
+
+# ------------------------------------------------------------------
+# Pulse — running glyphs alternate between two characters
+# ------------------------------------------------------------------
+
+
+class TestRunningPulse:
+    """Running items pulse; static statuses don't.
+
+    The pulse is a presentation detail layered on top of the canonical
+    glyph map, so ``glyphs_plain()`` (the assertion API used elsewhere)
+    keeps returning the canonical glyph and we inspect ``render()``
+    directly to see the alternate frame.
+    """
+
+    @pytest.mark.asyncio
+    async def test_pulse_timer_runs_only_when_a_running_item_exists(self) -> None:
+        all_done = [RailItem(id=1, status="done"), RailItem(id=2, status="done")]
+        app = _Harness(all_done)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            rail = app.query_one(PlanStatusRail)
+            assert rail._pulse_timer is None
+
+        with_running = _fixture_items()  # contains id=2 running
+        app = _Harness(with_running)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            rail = app.query_one(PlanStatusRail)
+            assert rail._pulse_timer is not None
+
+    @pytest.mark.asyncio
+    async def test_alternate_frame_uses_pulse_glyph(self) -> None:
+        items = _fixture_items()
+        app = _Harness(items)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            rail = app.query_one(PlanStatusRail)
+            # On-frame: render uses the canonical running glyph.
+            on_frame = rail.render().plain
+            assert STATUS_GLYPHS["running"] in on_frame
+            # Force the off-frame and re-render.
+            rail._pulse_on = False
+            rail.refresh()
+            await pilot.pause()
+            off_frame = rail.render().plain
+            assert "◎" in off_frame
+            assert STATUS_GLYPHS["running"] not in off_frame
+
+    @pytest.mark.asyncio
+    async def test_pulse_stops_when_last_running_item_finishes(self) -> None:
+        items = [RailItem(id=1, status="running")]
+        app = _Harness(items)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            rail = app.query_one(PlanStatusRail)
+            assert rail._pulse_timer is not None
+            rail.post_message(PlanStatusRail.ItemStatusChanged(1, "done"))
+            await pilot.pause()
+            assert rail._pulse_timer is None

--- a/tests/widgets/test_project_state_pane_orch.py
+++ b/tests/widgets/test_project_state_pane_orch.py
@@ -55,6 +55,7 @@ class _StubModel:
     issue_number: int | None = None
     items: list[Any] = field(default_factory=list)
     verdict: str = "running"
+    phase: str = "Running"
     plan_dir: Path = field(
         default_factory=lambda: Path("/nonexistent-stub-plan")
     )

--- a/tests/widgets/test_section_status_badge.py
+++ b/tests/widgets/test_section_status_badge.py
@@ -1,0 +1,117 @@
+"""Tests for the right-pane section status badge."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+
+from textual.app import App
+
+from toad.widgets.section_status_badge import (
+    BadgeState,
+    SectionStatusBadge,
+    _relative_time,
+)
+
+
+def _strip(badge: SectionStatusBadge) -> str:
+    """Plain-text rendering of the badge's current Rich Text."""
+    return badge.render().plain
+
+
+class _Harness(App):
+    def __init__(self, badge: SectionStatusBadge) -> None:
+        super().__init__()
+        self.badge = badge
+
+    def compose(self):
+        yield self.badge
+
+
+class TestRelativeTime:
+    def test_seconds(self) -> None:
+        when = datetime.now(tz=timezone.utc) - timedelta(seconds=5)
+        assert _relative_time(when) == "5s ago"
+
+    def test_minutes(self) -> None:
+        when = datetime.now(tz=timezone.utc) - timedelta(minutes=3, seconds=2)
+        assert _relative_time(when) == "3m ago"
+
+    def test_hours(self) -> None:
+        when = datetime.now(tz=timezone.utc) - timedelta(hours=2)
+        assert _relative_time(when) == "2h ago"
+
+    def test_just_now(self) -> None:
+        when = datetime.now(tz=timezone.utc)
+        assert _relative_time(when) == "just now"
+
+
+class TestRendering:
+    async def _mounted(self, badge: SectionStatusBadge) -> str:
+        async with _Harness(badge).run_test() as pilot:
+            await pilot.pause()
+            return _strip(badge)
+
+    def test_idle_renders_label(self) -> None:
+        async def run() -> str:
+            return await self._mounted(SectionStatusBadge(BadgeState.IDLE))
+
+        text = asyncio.run(run())
+        assert "IDLE" in text
+        assert "●" in text or "○" in text
+
+    def test_error_with_message(self) -> None:
+        async def run() -> str:
+            badge = SectionStatusBadge(BadgeState.ERROR, message="GH 401")
+            return await self._mounted(badge)
+
+        text = asyncio.run(run())
+        assert "ERROR" in text
+        assert "GH 401" in text
+
+    def test_mark_updated_adds_relative_time(self) -> None:
+        async def run() -> str:
+            badge = SectionStatusBadge(BadgeState.POLLING)
+            async with _Harness(badge).run_test() as pilot:
+                await pilot.pause()
+                badge.mark_updated()
+                await pilot.pause()
+                return _strip(badge)
+
+        text = asyncio.run(run())
+        # mark_updated() ran an instant ago — must show "just now" (or 0s).
+        assert "just now" in text or "0s ago" in text
+
+    def test_set_state_changes_label(self) -> None:
+        async def run() -> str:
+            badge = SectionStatusBadge(BadgeState.IDLE)
+            async with _Harness(badge).run_test() as pilot:
+                await pilot.pause()
+                badge.set_state(BadgeState.LIVE)
+                await pilot.pause()
+                return _strip(badge)
+
+        assert "LIVE" in asyncio.run(run())
+
+
+class TestPulse:
+    def test_pulse_only_for_live_states(self) -> None:
+        """The pulse timer is created for ``LIVE`` / ``POLLING`` /
+        ``UPDATING`` and stopped for static states. We assert against
+        the private timer because the visual blink is what the test
+        is fundamentally about, not a side effect.
+        """
+
+        async def run() -> tuple[bool, bool]:
+            badge = SectionStatusBadge(BadgeState.LIVE)
+            async with _Harness(badge).run_test() as pilot:
+                await pilot.pause()
+                live_has_timer = badge._pulse_timer is not None
+                badge.set_state(BadgeState.IDLE)
+                await pilot.pause()
+                idle_has_timer = badge._pulse_timer is not None
+                return live_has_timer, idle_has_timer
+
+        live, idle = asyncio.run(run())
+        assert live is True
+        assert idle is False

--- a/tests/widgets/test_worker_log_formatter.py
+++ b/tests/widgets/test_worker_log_formatter.py
@@ -1,0 +1,189 @@
+"""Tests for the worker-log NDJSON formatter."""
+
+from __future__ import annotations
+
+import json
+
+from toad.widgets.worker_log_formatter import WorkerLogFormatter
+
+
+def _line(payload: dict) -> str:
+    return json.dumps(payload) + "\n"
+
+
+class TestStreamJsonRendering:
+    def test_assistant_text_block(self) -> None:
+        f = WorkerLogFormatter()
+        rendered = f.feed(
+            _line(
+                {
+                    "type": "assistant",
+                    "message": {
+                        "content": [{"type": "text", "text": "Reading the plan."}]
+                    },
+                }
+            )
+        )
+        assert "🤖 Reading the plan." in rendered
+
+    def test_tool_use_uses_path_when_present(self) -> None:
+        f = WorkerLogFormatter()
+        rendered = f.feed(
+            _line(
+                {
+                    "type": "assistant",
+                    "message": {
+                        "content": [
+                            {
+                                "type": "tool_use",
+                                "name": "Read",
+                                "input": {"file_path": "src/toad/foo.py"},
+                            }
+                        ]
+                    },
+                }
+            )
+        )
+        assert "🔧 Read(src/toad/foo.py)" in rendered
+
+    def test_tool_use_command_for_bash(self) -> None:
+        f = WorkerLogFormatter()
+        rendered = f.feed(
+            _line(
+                {
+                    "type": "assistant",
+                    "message": {
+                        "content": [
+                            {
+                                "type": "tool_use",
+                                "name": "Bash",
+                                "input": {"command": "uv run pytest -q"},
+                            }
+                        ]
+                    },
+                }
+            )
+        )
+        assert "🔧 Bash(uv run pytest -q)" in rendered
+
+    def test_tool_result_emits_paper_icon(self) -> None:
+        f = WorkerLogFormatter()
+        rendered = f.feed(
+            _line(
+                {
+                    "type": "user",
+                    "message": {
+                        "content": [
+                            {
+                                "type": "tool_result",
+                                "tool_use_id": "x",
+                                "content": [
+                                    {"type": "text", "text": "hello world"}
+                                ],
+                            }
+                        ]
+                    },
+                }
+            )
+        )
+        assert "📄 hello world" in rendered
+
+    def test_tool_result_error_uses_warning(self) -> None:
+        f = WorkerLogFormatter()
+        rendered = f.feed(
+            _line(
+                {
+                    "type": "user",
+                    "message": {
+                        "content": [
+                            {
+                                "type": "tool_result",
+                                "is_error": True,
+                                "content": "boom",
+                            }
+                        ]
+                    },
+                }
+            )
+        )
+        assert "⚠ boom" in rendered
+
+    def test_result_event_success(self) -> None:
+        f = WorkerLogFormatter()
+        rendered = f.feed(
+            _line({"type": "result", "is_error": False, "result": "Item 1 complete."})
+        )
+        assert "✅ Item 1 complete." in rendered
+
+    def test_result_event_error(self) -> None:
+        f = WorkerLogFormatter()
+        rendered = f.feed(_line({"type": "result", "is_error": True, "result": "boom"}))
+        assert rendered.startswith("❌ boom")
+
+    def test_system_init_emits_session_marker(self) -> None:
+        f = WorkerLogFormatter()
+        rendered = f.feed(
+            _line(
+                {
+                    "type": "system",
+                    "subtype": "init",
+                    "model": "claude-opus-4-7[1m]",
+                }
+            )
+        )
+        assert "session start" in rendered
+        assert "claude-opus-4-7[1m]" in rendered
+
+    def test_rate_limit_event_dropped(self) -> None:
+        f = WorkerLogFormatter()
+        rendered = f.feed(_line({"type": "rate_limit_event", "rate_limit_info": {}}))
+        assert rendered == ""
+
+
+class TestPassThrough:
+    def test_plain_text_passes_through(self) -> None:
+        f = WorkerLogFormatter()
+        rendered = f.feed("--- worker 1 exited ---\n")
+        assert "--- worker 1 exited ---" in rendered
+
+    def test_malformed_json_passes_through(self) -> None:
+        """A line that looks like JSON but doesn't parse should still
+        appear so the user sees real engine output instead of silence."""
+        f = WorkerLogFormatter()
+        rendered = f.feed("{not actually json}\n")
+        assert "{not actually json}" in rendered
+
+    def test_blank_line_dropped(self) -> None:
+        f = WorkerLogFormatter()
+        assert f.feed("\n\n") == ""
+
+
+class TestBuffering:
+    def test_partial_line_buffered_until_newline(self) -> None:
+        """Chunks from `_scan_logs` are byte ranges, not line-aligned —
+        a JSON event split across two `feed()` calls must not get
+        rendered as two malformed halves."""
+        f = WorkerLogFormatter()
+        line = _line({"type": "result", "result": "ok"})
+        head, tail = line[:20], line[20:]
+        assert f.feed(head) == ""
+        rendered = f.feed(tail)
+        assert "✅ ok" in rendered
+
+    def test_multiple_events_in_one_chunk(self) -> None:
+        f = WorkerLogFormatter()
+        bulk = _line(
+            {
+                "type": "assistant",
+                "message": {"content": [{"type": "text", "text": "a"}]},
+            }
+        ) + _line({"type": "result", "result": "b"})
+        rendered = f.feed(bulk)
+        assert "🤖 a" in rendered
+        assert "✅ b" in rendered
+
+    def test_flush_emits_unterminated_tail(self) -> None:
+        f = WorkerLogFormatter()
+        f.feed("trailing without newline")
+        flushed = f.flush()
+        assert "trailing without newline" in flushed


### PR DESCRIPTION
## Summary

Pass over the right-pane sections to make refresh activity visible at a glance, plus two papercut fixes the work surfaced.

### Liveness — section status

- New `SectionStatusBadge` widget — single-line pill (`● LIVE  ·  3s ago`) with six well-known states (LIVE / POLLING / UPDATING / IDLE / ERROR / OFFLINE), pulsing dot, 1Hz relative-time tick.
- Mounted on Context / Planning / State / Outreach — UPDATING during fetch, POLLING + relative timestamp on success, ERROR with short message on failure, OFFLINE when the provider is missing.
- One badge per plan-execution tab tied to `PlanExecutionModel.phase` (Running → LIVE, Review/Verify → UPDATING, Done → IDLE with verdict, Failed → ERROR).
- State section uses POLLING (not LIVE) on purpose — "live" is overloaded in canon-land (live trading vs paper) and the section's source is file-tail on `.canon/state.json` anyway.

### Liveness — motion

- `PlanStatusRail` running glyph pulses ◉ ↔ ◎ on a 700ms timer; idle plans don't tick.
- `TaskTable` cells whose value changed between polls get a 1.5s yellow flash. First load is silent (no flashing every cell as a baseline).
- Outreach `StatLine` / `Histogram` totals tick green↑ / red↓ for 700ms on change.

### Visual

- Per-section accent left-borders: cyan / magenta / green / orange / yellow.
- Toolbar buttons restyled as transparent chips (background only on hover/active).

### UX

- Bypass-permissions default — claude-code-acp's `bypassPermissions` mode is auto-applied on the first `SetModes` event so the conductor stops prompting on every tool. Once per session, manual changes stick, opt out with `CANON_NO_AUTO_BYPASS=1`.
- Fix: closing the last plan tab via X surfaces the running-plans list instead of leaving the section blank (Textual leaves `tabs.active` pointing at the just-removed id; we now activate the empty pane explicitly via `call_after_refresh`).

### Doc

- `docs/core-request-orchestrator-status-watchdog.md` — status watchdog request to `claude-code-config` (EXIT trap + heartbeat sweep + per-item stale flip), plus the one-line `canon-start.md` patch to surface the State panel automatically. Lives in canon-tui because it travels with the panel work that depends on it.

## Test plan

- [x] `uv run pytest tests/ -q` — 374 pass (23 pre-existing gantt failures, unrelated)
- [x] `uv run ruff check` clean on touched files
- [x] `uv run python tools/verify-tui.py --widget imports` pass
- [x] Headless mount tests: badges render, state transitions propagate, replay works
- [x] Reproduced the close-last-plan-tab blank-section bug, fixed it, regression test pinned
- [x] End-to-end Claude `--output-format stream-json` smoke (carried over from the prior worker-log work) — formatter still parses cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)