### PR TITLE
chore: bump version to 0.7.18

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canon-tui"
-version = "0.7.17"
+version = "0.7.18"
 description = "Canon TUI — a unified experience for AI in your terminal."
 readme = "README.md"
 requires-python = ">=3.14"


### PR DESCRIPTION
## Summary
- Bumps `pyproject.toml` from 0.7.17 → 0.7.18
- Covers three commits on main since the last release:
  - `4015fbd` timeline: make project_number optional
  - `8556516` task table: add issue number column to all views
  - `9b90a8f` docs: add third-party module integration guide

## Test plan
- [ ] `uv sync` resolves cleanly
- [ ] `uv run canon --version` reports 0.7.18

🤖 Generated with [Claude Code](https://claude.com/claude-code)