### PR TITLE
fix: plan tab badge stuck on running after orch completes

### DIFF
--- a/src/toad/data/plan_execution_model.py
+++ b/src/toad/data/plan_execution_model.py
@@ -298,11 +298,14 @@ class PlanExecutionModel:
         self._phase = self._derive_phase()
 
     def _is_terminal(self) -> bool:
-        if self._status in _TERMINAL_STATUSES:
-            return True
-        if self._verdict in _TERMINAL_VERDICTS:
-            return True
-        return False
+        # Only consider the plan terminal when the top-level ``status``
+        # field is explicitly terminal. Previously we also checked
+        # ``self._verdict in _TERMINAL_VERDICTS`` here, but that caused
+        # PlanFinished to fire as soon as ``finalReview.result`` was set
+        # — before the engine wrote ``status = "completed"``. The tab
+        # badge would freeze because a later poll (with the real
+        # "completed" status) was suppressed by ``_finished_emitted``.
+        return self._status in _TERMINAL_STATUSES
 
     def _derive_phase(self) -> str:
         if self._status == "completed":

--- a/tests/data/test_plan_execution_model.py
+++ b/tests/data/test_plan_execution_model.py
@@ -416,6 +416,90 @@ class TestPlanFinished:
         assert finished[0].verdict == "SHIP"
         assert model.verdict == "SHIP"
 
+    def test_no_premature_finished_when_verdict_set_before_status(
+        self, plan_dir: Path
+    ) -> None:
+        """Regression: the engine writes ``finalReview.result = "SHIP"``
+        before setting ``status = "completed"``. The model must NOT fire
+        ``PlanFinished`` until ``status`` is actually terminal —
+        otherwise the tab badge freezes on "running" because the later
+        poll (with ``status = "completed"``) is suppressed by the
+        ``_finished_emitted`` guard.
+        """
+        done_items = [
+            {"id": 1, "description": "alpha", "deps": [], "status": "done"},
+            {"id": 2, "description": "beta", "deps": [1], "status": "done"},
+        ]
+        target = _Recorder()
+        model = PlanExecutionModel(plan_dir, target=target, poll=True)
+        model.start()
+        try:
+            # Step 1: engine writes finalReview.result but status is
+            # still "running" (review just finished, verify not started).
+            payload_review_done = _state_payload(items=done_items)
+            payload_review_done["finalReview"] = {
+                "result": "SHIP",
+                "status": "done",
+            }
+            # status stays default (no "status" key → model treats as "running")
+            payload_review_done.pop("status", None)
+            _write_state(plan_dir, payload_review_done)
+            model.poll_now()
+
+            premature = [
+                m
+                for m in target.messages
+                if isinstance(m, PlanExecutionTab.PlanFinished)
+            ]
+            assert premature == [], (
+                "PlanFinished must not fire before status is terminal"
+            )
+            assert model.verdict == "SHIP"
+            assert model.phase == "Running"
+
+            # Step 2: engine sets status = "verifying".
+            payload_verifying = dict(payload_review_done)
+            payload_verifying["status"] = "verifying"
+            payload_verifying["verification"] = {
+                "status": "running",
+                "uncheckedCount": 2,
+            }
+            _write_state(plan_dir, payload_verifying)
+            model.poll_now()
+
+            still_premature = [
+                m
+                for m in target.messages
+                if isinstance(m, PlanExecutionTab.PlanFinished)
+            ]
+            assert still_premature == [], (
+                "PlanFinished must not fire during verification"
+            )
+            assert model.phase == "Verify"
+
+            # Step 3: engine writes status = "completed".
+            payload_completed = _state_payload(
+                items=done_items, verdict="SHIP"
+            )
+            payload_completed["verification"] = {
+                "status": "passed",
+                "uncheckedCount": 0,
+            }
+            _write_state(plan_dir, payload_completed)
+            model.poll_now()
+
+            finished = [
+                m
+                for m in target.messages
+                if isinstance(m, PlanExecutionTab.PlanFinished)
+            ]
+            assert len(finished) == 1
+            assert finished[0].verdict == "SHIP"
+            assert model.phase == "Done"
+            assert model.status == "completed"
+        finally:
+            model.stop()
+
     def test_emits_at_most_once_per_terminal_verdict(self, plan_dir: Path) -> None:
         target = _Recorder()
         model = PlanExecutionModel(plan_dir, target=target, poll=True)


### PR DESCRIPTION
## Problem

The plan execution tab badge stayed frozen on "running" after the orchestrator completed a plan.

## Root Cause

`_is_terminal()` in `PlanExecutionModel` returned `True` when `finalReview.result == "SHIP"` — before the engine wrote `status = "completed"`. This caused `PlanFinished` to fire prematurely. When the engine later wrote the real terminal status, the `_finished_emitted` guard suppressed the notification, so the tab badge never refreshed.

The engine writes state in this order:
1. `finalReview.result = "SHIP"` (status still `"running"`)
2. `status = "verifying"`
3. `status = "completed"`

A poll between steps 1 and 2 fired `PlanFinished` too early — the tab badge stayed frozen because `phase` was still `"Running"`.

## Fix

`_is_terminal()` now only checks `self._status in _TERMINAL_STATUSES`. `PlanFinished` waits for the engine to explicitly set a terminal status.

## Test

`test_no_premature_finished_when_verdict_set_before_status` reproduces the exact 3-step engine sequence and asserts `PlanFinished` only fires at step 3.