### PR TITLE
Release 0.7.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+### Added
+- Growth right-pane plugin — host slot in canon-tui plus the private `dega_growth` submodule (Overview / Discord / Telegram / Templates sub-tabs, Sheet-backed sends with mark-sent action, markdown templates) (`feat/growth-provider`) — 2026-05-08
+
 ### Changed
 - Live updates for PlanExecutionTab — directory watch + interval backstop (`20260427-plan-tab-live-updates`) — 2026-04-27
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canon-tui"
-version = "0.7.18"
+version = "0.7.19"
 description = "Canon TUI — a unified experience for AI in your terminal."
 readme = "README.md"
 requires-python = ">=3.14"


### PR DESCRIPTION
## Summary

Release PR — bumps canon-tui to **0.7.19** and brings develop back into sync with main (gitflow restored).

This is purely a version + changelog update. The features that 0.7.19 covers (Growth right-pane plugin: PR #58 + DEGAorg/dega_growth#1) already landed on main earlier today.

## Test plan

- [ ] `git diff origin/main...origin/develop` shows only the version + changelog change.
- [ ] `pyproject.toml` version reads `0.7.19`.
- [ ] `CHANGELOG.md` has the Growth plugin entry under `[Unreleased]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)