### PR TITLE
fix(acp): inject conductor + agent_context at system-prompt level via _meta

### DIFF
--- a/src/toad/acp/agent.py
+++ b/src/toad/acp/agent.py
@@ -132,7 +132,6 @@ class Agent(AgentBase):
         self._message_target: MessagePump | None = None
 
         self._terminal_count: int = 0
-        self._context_injected: bool = False
 
         log_filename: str = generate_datetime_filename(f"{agent['name']}", ".txt")
         if log_path := os.environ.get("TOAD_LOG"):
@@ -672,13 +671,11 @@ class Agent(AgentBase):
         prompt_content_blocks = await asyncio.to_thread(
             build_prompt, self.project_root_path, prompt
         )
-        if not self._context_injected:
-            self._context_injected = True
-            context = self._load_agent_context()
-            if context:
-                prompt_content_blocks.insert(
-                    0, {"type": "text", "text": context}
-                )
+        # Conductor + bundled agent_context are installed at the
+        # system-prompt level via ``acp_new_session``'s
+        # ``_meta.systemPrompt.append``. No need to re-inject them as
+        # user-prompt content here — that was the prior approach and it
+        # made the rules advisory rather than binding.
         return await self.acp_session_prompt(prompt_content_blocks)
 
     @staticmethod
@@ -742,11 +739,29 @@ class Agent(AgentBase):
             self.auth_methods = auth_methods
 
     async def acp_new_session(self) -> None:
-        """Create a new session."""
+        """Create a new session.
+
+        Conductor + bundled agent_context ride at the **system-prompt**
+        level via ``_meta.systemPrompt.append``. The adapter
+        (``claude-code-acp``) merges this text into the underlying
+        ``claude_code`` preset at session creation, so the rules are
+        binding for the agent. Injecting the same text as user-prompt
+        content (the prior approach) made the rules advisory and lost
+        conflicts with the preset's own defaults — see
+        ``docs/conductor-execution-contract.md`` for the analysis.
+        """
+        system_prompt_append = self._load_agent_context()
+        session_meta: dict | None = None
+        if system_prompt_append:
+            session_meta = {
+                "systemPrompt": {"append": system_prompt_append},
+            }
+
         with self.request():
             session_new_response = api.session_new(
                 str(self.project_root_path),
                 [],
+                _meta=session_meta,
             )
         response = await session_new_response.wait()
         assert response is not None

--- a/src/toad/acp/api.py
+++ b/src/toad/acp/api.py
@@ -21,9 +21,19 @@ def initialize(
 
 @API.method(name="session/new")
 def session_new(
-    cwd: str, mcpServers: list[protocol.McpServer]
+    cwd: str,
+    mcpServers: list[protocol.McpServer],
+    _meta: dict | None = None,
 ) -> protocol.NewSessionResponse:
-    """https://agentclientprotocol.com/protocol/session-setup#session-id"""
+    """https://agentclientprotocol.com/protocol/session-setup#session-id
+
+    The optional ``_meta`` carries adapter-specific extensions. For
+    ``claude-code-acp`` it may include ``systemPrompt`` to override or
+    append to the default ``claude_code`` preset — see
+    ``acp-agent.js`` (``params._meta.systemPrompt``). Pass either
+    ``{"systemPrompt": "<text>"}`` to replace the preset entirely or
+    ``{"systemPrompt": {"append": "<text>"}}`` to append.
+    """
     ...
 
 


### PR DESCRIPTION
## Why

When `canon` launches Claude Code via `claude-code-acp`, the
Conductor prompt and bundled `agent_context.md` were inserted as the
**first user-prompt content block** on the session's first prompt
(``send_prompt`` → ``_context_injected``). That made the rules
*advisory*: Claude reads them as user input and weighs them against
the default ``claude_code`` preset's binding instructions and its
own delegation heuristics. In practice the agent often lost that
conflict — delegating infrastructure bash blocks to Task subagents
(which fabricated completion) or narrating "Init complete / Scaffold
created / X packages installed" without firing the corresponding
Bash tool calls. Empty project directories shipped with cheerful
chat logs.

Full diagnostic chain, including the rule-tightening PRs we burned
on `DEGAorg/claude-code-config` (#329 #330 #331 #332 #333) before
finding the real lever:

[`docs/reviews/canon-tui-hallucination-discovery.md`](https://github.com/DEGAorg/claude-code-config/blob/develop/docs/reviews/canon-tui-hallucination-discovery.md) on the conductor repo.

## The lever

``claude-code-acp`` (the ACP adapter we spawn) already supports
overriding or appending to its default system prompt via
``params._meta.systemPrompt`` on ``session/new``
([acp-agent.js:756-767](https://github.com/zed-industries/claude-code-acp/blob/main/src/acp-agent.ts)):

```js
let systemPrompt = { type: \"preset\", preset: \"claude_code\" };
if (params._meta?.systemPrompt) {
    const customPrompt = params._meta.systemPrompt;
    if (typeof customPrompt === \"string\") {
        systemPrompt = customPrompt;                  // replace
    } else if (typeof customPrompt === \"object\" &&
               \"append\" in customPrompt &&
               typeof customPrompt.append === \"string\") {
        systemPrompt.append = customPrompt.append;    // append
    }
}
```

This PR routes the Conductor + bundled `agent_context` through the
**append** form. Default Claude Code behavior is preserved AND our
rules ride at the system-prompt level (binding).

## Changes

- **`src/toad/acp/api.py`** — add `_meta: dict | None = None` to the
  ``session/new`` API signature. The pattern is already used elsewhere
  in this file (``session/cancel`` line 39).

- **`src/toad/acp/agent.py::acp_new_session`** — build
  `_meta={\"systemPrompt\": {\"append\": <conductor + agent_context>}}`
  from the existing `_load_agent_context()` helper and pass it
  through to `api.session_new(..., _meta=...)`.

- **`src/toad/acp/agent.py::send_prompt`** — drop the now-redundant
  user-prompt injection that prepended the same text on the first
  turn. Re-injecting it would double the token cost and re-create
  the user-message-position weakness.

- `self._context_injected` flag becomes dead state; removed.

## What this fixes downstream

Once this lands, several behavioral rules on `DEGAorg/claude-code-config`
become removable because they were workarounds for the
user-prompt-position weakness:

- The \"⚠️ Binding constraints — read first\" preamble in
  `agents/conductor.md` (added in #333) can revert to a normal Rules
  section. Binding-vs-advisory is now enforced by the protocol.
- The scope override for `agent_context.md`'s \"Never echo tool output\"
  in `commands/canon-start.md` (#331) becomes unnecessary once we also
  narrow that rule upstream — separate follow-up on canon-tui.
- The `CANON_DEBUG_PROBE` env-gated probe (#332) can be removed after
  two consecutive green runs.

## Test plan

- [ ] Merge to main
- [ ] `uv tool install --reinstall <local checkout>` (or
      `uv tool install --reinstall git+https://github.com/DEGAorg/canon-tui.git@main`)
- [ ] Fresh canon-tui session in a fresh empty dir
- [ ] Run `/canon-start` inside that session
- [ ] Verify on the first attempt, no per-turn overrides:
   - [ ] No Task tool calls in the transcript
   - [ ] Scaffold lands (~46 entries)
   - [ ] State panel moves
   - [ ] Chat is one-line-per-phase
   - [ ] Three-way wallet check matches: agent chat == `.canon/wallet.env` on disk == `canon-cli wallet info --pretty` from outside canon-tui

## Follow-ups (separate PRs)

1. Narrow `src/toad/data/agent_context.md`'s \"Never echo tool output\"
   rule to apply only to `canon-ctl` panel-control output. As-is it
   suppresses every tool's output and forced us to add scope overrides
   in canon-start.md. With this PR's system-prompt move, the rule is
   now binding — making its overreach more impactful — so narrowing it
   is worth doing soon.

2. Test coverage for ``acp_new_session``: assert ``_meta.systemPrompt.append``
   carries conductor text when `~/.claude/agents/conductor.md` exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)