### PR TITLE
docs: Conductor execution contract

### DIFF
--- a/docs/conductor-execution-contract.md
+++ b/docs/conductor-execution-contract.md
@@ -1,0 +1,54 @@
+# Conductor execution contract
+
+The Conductor is the top-level agent that canon-tui spawns inside a
+`canon run <path>` session. It is allowed to **execute deterministic
+infrastructure scripts directly** — it does not delegate them. Concretely:
+
+- Canon scripts under `${DEGA_CORE_HOME}/scripts/` (`canon-scaffold.sh`,
+  `canon-runner.sh`, `canon-live-readiness.sh`, `canon.sh`, ...).
+- `canon-cli` with any subcommand (e.g. `canon-cli wallet ensure --pretty`).
+- Package-manager installs (`pnpm install`, `npm install`).
+- Read-only inspection commands (`ls`, `cat`, `grep`, `git status`,
+  `gh pr list`, ...) needed to gather session state.
+- Bash blocks defined inline in slash-command files under
+  `~/.claude/commands/` or `.claude/commands/`.
+
+**Code authoring still goes through delegation** — subagents and the
+orchestrator handle file edits, test runs, and project source changes.
+
+## Environment contract
+
+When canon-tui spawns the agent subprocess it sets:
+
+| Variable    | Meaning                                                    |
+| ----------- | ---------------------------------------------------------- |
+| `TOAD_CWD`  | Absolute path of the project root canon-tui is anchored to |
+| `CANON_TUI` | `"1"` — signals slash-command TUI detection that we are it |
+
+`CANON_TUI=1` is the trigger the `/canon-start` flow keys off. Without it
+the Conductor falls back to a degraded "delegation-only" persona that has
+been observed fabricating shell output instead of running scaffolding
+scripts. The regression test `tests/acp/test_agent_subprocess_env.py`
+pins this contract.
+
+## Reporting a fabricated-output bug
+
+If the agent reports work it did not actually do — wallet addresses that
+do not match `~/.degacore/bin/canon-cli wallet info --pretty`, scaffold
+file lists that do not match `ls -la`, claims of "templates fetched" when
+nothing landed — that is a tool-relay or persona-conflict bug.
+
+To file it, reproduce with the smoking-gun diagnostic from the handoff:
+
+1. In a fresh empty directory, run `canon run .`.
+2. Ask the agent in chat: `Run "ls -la" and "cat .canon/wallet.env" and
+   quote both verbatim.`
+3. From a separate terminal in the same directory, run the same two
+   commands.
+4. If the two transcripts disagree, the bug is live. Attach both
+   transcripts (agent claim vs. real shell output) to the issue.
+
+The end-to-end smoking-gun and root-cause analysis live in the
+[`canon-tui-agent-hallucination-handoff.md`](https://github.com/DEGAorg/claude-code-config/blob/develop/docs/reviews/canon-tui-agent-hallucination-handoff.md)
+doc under `DEGAorg/claude-code-config`. File the canon-tui-side issue on
+`DEGAorg/canon-tui` with a link to that handoff.

--- a/docs/conductor-setup.md
+++ b/docs/conductor-setup.md
@@ -4,6 +4,14 @@ Conductor extends Toad with project management features: a socket controller
 for external automation, a Project State split-screen pane with a Gantt
 timeline, and agent context injection so AI agents can control the TUI.
 
+> **Heads up:** the agent canon-tui spawns is allowed to run deterministic
+> infrastructure scripts (canon-scaffold.sh, canon-cli, pnpm install)
+> directly — it does **not** delegate them. See
+> [`conductor-execution-contract.md`](conductor-execution-contract.md) for
+> the full contract, the `CANON_TUI` / `TOAD_CWD` env variables we set on
+> the spawned agent, and how to file a tool-relay bug if the agent ever
+> reports work it did not actually do.
+
 ## Prerequisites
 
 - Python 3.14+ with the Toad venv set up (see main README)


### PR DESCRIPTION
## Summary

- Adds \`docs/conductor-execution-contract.md\` — what the Conductor may execute directly (canon-scripts, canon-cli, pnpm install, read-only inspection) vs. what still delegates to subagents/orchestrator.
- Adds a callout in \`docs/conductor-setup.md\` pointing at it.
- Documents the smoking-gun reproduction (\`ls -la\` + \`cat .canon/wallet.env\` agent claim vs. real shell) so future fabrication reports can be filed concretely.

Pairs with claude-code-config 0.1.8 (Conductor persona + canon-start verbatim-output rule) and #61 (system-prompt-level injection via \`_meta\`) — those landed the fix; this doc captures the contract for future triage. Full diagnostic in \`DEGAorg/claude-code-config/docs/reviews/canon-tui-agent-hallucination-handoff.md\`.

Supersedes #63 (which also carried a now-defensive \`CANON_TUI=1\` env var + tests).

## Test plan

- [x] No code/test changes — docs-only diff
- [x] Links resolve