### PR TITLE
fix(acp): eager-load ACP tools to stop deferred-MCP fabrication (0.7.21)

### DIFF
--- a/docs/canon-tui-fabrication-problem.md
+++ b/docs/canon-tui-fabrication-problem.md
@@ -1,0 +1,81 @@
+# Canon-TUI Fabrication — Root Cause
+
+When the agent inside Canon TUI reported file edits or shell commands
+that never actually ran on disk, the cause was that the
+ACP-namespaced filesystem and shell tools were being deferred behind
+the Claude Agent SDK's `ToolSearch` tool. The agent occasionally
+skipped the discovery step and narrated a plausible result instead of
+invoking the tool.
+
+> Symptom signature: the chat reads "wrote `probe.txt`", "scaffolded
+> the project", or "wallet created at 0x…", but `ls` on the target
+> directory comes back empty. Plain `claude` from the terminal — same
+> binary, same auth — works fine on the same prompt.
+
+## Mechanism
+
+```
+Canon TUI (Python)
+  └─ spawns `claude-code-acp` subprocess (Node)
+       └─ creates an in-process MCP server named "acp"
+            ├─ registers tools: read, write, edit, bash,
+            │   bashOutput, killShell (mcp-server.js)
+            └─ passes mcpServers["acp"] to the Claude Agent SDK
+       └─ DISALLOWS Claude Code's native Read/Write/Edit/Bash/...
+          via options.disallowedTools (acp-agent.js)
+            ⇒ the agent can only act through the ACP-namespaced
+              versions
+
+Claude Agent SDK (@anthropic-ai/claude-agent-sdk ≥ 0.2.44)
+  └─ defers all MCP tools behind `ToolSearch` by default
+       ⇒ the ACP tools appear as
+         "Deferred tools (available via ToolSearch before first use):
+            • ACP — Read, Write, Edit, Bash, BashOutput, KillShell"
+
+Result
+  └─ to invoke `Bash` the agent must call `ToolSearch` first.
+     When it skips that step it has no callable tool and narrates a
+     plausible result instead — fabrication.
+```
+
+## Why plain `claude` is unaffected
+
+Plain `claude` runs the Claude Code harness, which exposes
+`Bash/Read/Write/Edit/...` as built-in (eager) tools. Canon TUI talks
+to the same binary indirectly via `claude-code-acp`, which removes
+the built-in versions and re-injects them as MCP-namespaced tools —
+and MCP tools are the ones the SDK defers.
+
+## How to recognize this regression
+
+1. The agent describes work it did not actually do (filesystem
+   side-effects missing on disk).
+2. Plain `claude` works on the same machine, same prompt.
+3. The session start banner lists tools under a "Deferred tools" or
+   "available via ToolSearch" header (look for the `ACP —` prefix).
+
+## Minimal reproducer
+
+```bash
+mkdir -p /tmp/canon-fabrication-probe
+canon /tmp/canon-fabrication-probe
+# In chat: Write a file named probe.txt with the contents "hello"
+ls /tmp/canon-fabrication-probe/probe.txt   # expect: file exists
+```
+
+Run the probe in a fresh directory each time — once a session has
+gone through `ToolSearch` for a tool, subsequent calls succeed
+regardless. The bug only shows at session start.
+
+## Related upstream tracking
+
+- [anthropics/claude-code#31002](https://github.com/anthropics/claude-code/issues/31002) — system-tool deferral discussion.
+- [anthropics/claude-agent-sdk-python#525](https://github.com/anthropics/claude-agent-sdk-python/issues/525) — ToolSearch / deferred-loading SDK controls.
+- The TypeScript SDK reads `ENABLE_TOOL_SEARCH` from `process.env` and
+  routes it through a mode selector (`tst`, `tst-auto`, `standard`,
+  `mcp-cli`). Setting the env to a falsy string forces `standard` mode
+  — no ToolSearch indirection — which is the fix we ship.
+
+## See also
+
+- [`canon-tui-fabrication-solution.md`](canon-tui-fabrication-solution.md) — the fix and how to verify it.

--- a/docs/canon-tui-fabrication-solution.md
+++ b/docs/canon-tui-fabrication-solution.md
@@ -1,0 +1,91 @@
+# Canon-TUI Fabrication — Fix
+
+Canon TUI sets `ENABLE_TOOL_SEARCH=false` in the environment of the
+`claude-code-acp` subprocess. The Claude Agent SDK reads this from
+`process.env` and selects `standard` tool mode, which eager-loads the
+ACP-namespaced filesystem and shell tools instead of deferring them
+behind `ToolSearch`. With those tools always available, the agent
+cannot "skip discovery" and fall back to narration. See
+[`canon-tui-fabrication-problem.md`](canon-tui-fabrication-problem.md)
+for the full chain.
+
+## Where the fix lives
+
+`src/toad/acp/agent.py`, in `_run_agent` just before the subprocess
+spawn:
+
+```python
+PIPE = asyncio.subprocess.PIPE
+env = os.environ.copy()
+env["TOAD_CWD"] = str(Path("./").absolute())
+# Force the Claude Agent SDK into "standard" tool mode so the
+# ACP-namespaced tools (Read/Write/Edit/Bash/BashOutput/KillShell
+# registered by claude-code-acp's MCP server) are eager-loaded
+# instead of deferred behind ToolSearch. ...
+env.setdefault("ENABLE_TOOL_SEARCH", "false")
+```
+
+`setdefault` is deliberate — a user who exports
+`ENABLE_TOOL_SEARCH=auto:25` (or any other valid SDK value) in their
+shell still wins.
+
+## Verifying after a Claude Code or SDK upgrade
+
+The SDK's mode-selector logic could change in a future release. Verify
+the fix still holds whenever you bump `claude-code-acp` or the
+underlying SDK:
+
+```bash
+# 1. Probe in a brand-new directory.
+mkdir -p /tmp/canon-fab-verify
+canon /tmp/canon-fab-verify
+# In chat: Write a file named probe.txt with the contents "hello".
+ls /tmp/canon-fab-verify/probe.txt   # must exist
+```
+
+Repeat three times in three different fresh directories before
+declaring it good — once a session has loaded the ACP tools via
+ToolSearch, the bug hides. Only fresh-session passes count.
+
+A heavier integration test:
+
+```bash
+mkdir -p /tmp/canon-fab-verify-canon-start
+canon /tmp/canon-fab-verify-canon-start
+# In chat: /canon-start
+# Then verify the scaffold landed:
+find /tmp/canon-fab-verify-canon-start -mindepth 1 | wc -l
+# Expect roughly the baseline entry count for the canon-start scaffold.
+```
+
+## If the symptom returns
+
+Try, in order:
+
+1. Confirm the env is actually reaching the subprocess:
+   ```python
+   # Temporary log in src/toad/acp/agent.py before create_subprocess_shell
+   self.log(f"[spawn-env] ENABLE_TOOL_SEARCH={env.get('ENABLE_TOOL_SEARCH')!r}")
+   ```
+   Look in `$XDG_STATE_HOME/toad/logs/Claude_Code_*.txt` for the line.
+2. Try `env["ENABLE_TOOL_SEARCH"] = "auto:100"` — this forces the
+   explicit `q===100 → standard` branch in the SDK's selector. Useful
+   if the falsy-string branch changes.
+3. Inspect the SDK's selector directly:
+   ```bash
+   SDK="$HOME/.npm-global/lib/node_modules/@zed-industries/claude-code-acp/node_modules/@anthropic-ai/claude-agent-sdk"
+   grep -aoE '.{80}ENABLE_TOOL_SEARCH.{120}' "$SDK/cli.js" | head
+   ```
+   The returned string values (`tst`, `tst-auto`, `standard`,
+   `mcp-cli`) drive whether ToolSearch is wired in.
+4. As a last resort, patch `claude-code-acp`'s `mcp-server.js` to
+   declare the ACP tools as eager when the MCP SDK supports it, or
+   open an upstream issue with `zed-industries/claude-code-acp`
+   requesting a knob.
+
+## Why we set this in the spawn env instead of upstream
+
+The cheapest stable surface we control is the subprocess env. Patching
+`claude-code-acp` or the SDK requires a release on their side; setting
+the env keeps the fix in this repo, reversible, and easy to remove
+once an upstream change makes it unnecessary.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canon-tui"
-version = "0.7.19"
+version = "0.7.21"
 description = "Canon TUI — a unified experience for AI in your terminal."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/src/toad/acp/agent.py
+++ b/src/toad/acp/agent.py
@@ -505,6 +505,13 @@ class Agent(AgentBase):
         PIPE = asyncio.subprocess.PIPE
         env = os.environ.copy()
         env["TOAD_CWD"] = str(Path("./").absolute())
+        # Force the Claude Agent SDK into "standard" tool mode so the
+        # ACP-namespaced tools (Read/Write/Edit/Bash/BashOutput/KillShell
+        # registered by claude-code-acp's MCP server) are eager-loaded
+        # instead of deferred behind ToolSearch. Deferred MCP tools were
+        # being skipped, causing the agent to narrate fabricated results.
+        # See docs/canon-tui-fabrication-problem.md.
+        env.setdefault("ENABLE_TOOL_SEARCH", "false")
 
         if (command := self.command) is None:
             self.post_message(


### PR DESCRIPTION
## Summary
- Sets `ENABLE_TOOL_SEARCH=false` on the `claude-code-acp` subprocess env in `src/toad/acp/agent.py` so the Claude Agent SDK eager-loads the ACP-namespaced `Read`/`Write`/`Edit`/`Bash`/`BashOutput`/`KillShell` tools instead of deferring them behind `ToolSearch`.
- Adds `docs/canon-tui-fabrication-problem.md` and `docs/canon-tui-fabrication-solution.md` documenting the chain (ACP adapter registers tools as MCP → SDK defers MCP tools → agent skips ToolSearch → fabrication) and how to verify the fix after SDK upgrades.
- Bumps version to 0.7.21.

## Background
Plain `claude` (Claude Code's own harness) worked fine on the same prompts. Inside Canon TUI, the agent narrated fake file edits and shell commands. Root cause: `claude-code-acp` disallows Claude Code's native tools and re-exposes them via an in-process MCP server; the SDK then routes MCP tools through `ToolSearch`, and the agent occasionally skipped discovery and fabricated results.

`setdefault` is intentional — a user-set `ENABLE_TOOL_SEARCH` still wins.

## Test plan
- [x] Probe in a fresh dir: `mkdir -p /tmp/probe && canon /tmp/probe`, chat "Write probe.txt with contents 'hello'", verify `ls /tmp/probe/probe.txt` exists.
- [x] `/canon-start` integration test in a fresh dir: scaffold lands on disk, `.canon/wallet.env` present.
- [ ] Reviewer: confirm `env.setdefault` call is hit before `create_subprocess_shell` (`src/toad/acp/agent.py:513`).
- [ ] Reviewer: confirm version bump in `pyproject.toml` (0.7.19 → 0.7.21).

🤖 Generated with [Claude Code](https://claude.com/claude-code)