### PR TITLE
v0.7.22 — fix(acp): strip parent Claude Code session env before spawn

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canon-tui"
-version = "0.7.21"
+version = "0.7.22"
 description = "Canon TUI — a unified experience for AI in your terminal."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/src/toad/acp/agent.py
+++ b/src/toad/acp/agent.py
@@ -23,6 +23,7 @@ from toad.acp import protocol
 from toad.acp import api
 from toad.acp.api import API
 from toad.acp import messages
+from toad.acp.env_prep import build_agent_subprocess_env
 from toad.acp.prompt import build as build_prompt
 from toad.db import DB
 from toad import paths
@@ -65,9 +66,7 @@ def generate_datetime_filename(
     return file_name_stem + suffix
 
 
-async def inject_subagent_completion(
-    conductor: Any, name: str, summary: str
-) -> None:
+async def inject_subagent_completion(conductor: Any, name: str, summary: str) -> None:
     """Post a synthetic completion message into the Conductor's session.
 
     Format: ``[subagent <name> completed: <summary>]`` — matches
@@ -503,15 +502,7 @@ class Agent(AgentBase):
         """Task to communicate with the agent subprocess."""
 
         PIPE = asyncio.subprocess.PIPE
-        env = os.environ.copy()
-        env["TOAD_CWD"] = str(Path("./").absolute())
-        # Force the Claude Agent SDK into "standard" tool mode so the
-        # ACP-namespaced tools (Read/Write/Edit/Bash/BashOutput/KillShell
-        # registered by claude-code-acp's MCP server) are eager-loaded
-        # instead of deferred behind ToolSearch. Deferred MCP tools were
-        # being skipped, causing the agent to narrate fabricated results.
-        # See docs/canon-tui-fabrication-problem.md.
-        env.setdefault("ENABLE_TOOL_SEARCH", "false")
+        env = build_agent_subprocess_env(os.environ, str(Path("./").absolute()))
 
         if (command := self.command) is None:
             self.post_message(
@@ -706,9 +697,7 @@ class Agent(AgentBase):
         socket_text = ""
         try:
             socket_text = (
-                files("toad.data")
-                .joinpath("agent_context.md")
-                .read_text("utf-8")
+                files("toad.data").joinpath("agent_context.md").read_text("utf-8")
             )
         except Exception:
             pass

--- a/src/toad/acp/env_prep.py
+++ b/src/toad/acp/env_prep.py
@@ -1,0 +1,57 @@
+"""Build the env passed to ``claude-code-acp`` and its child ``claude``.
+
+Lives in its own module so the helper can be imported without pulling
+in the full ``toad.acp.agent`` graph (which has a known circular import
+with ``toad.acp.messages``). Tests can target this module directly
+without spinning up the rest of the package.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+
+# Env vars Claude Code sets in its own session and that leak into any
+# child process started from a Claude Code terminal (including a child
+# shell of one). When canon-tui spawns ``claude-code-acp`` it must strip
+# these so the inner ``claude`` process does not detect a parent session
+# and refuse to start ("Claude Code cannot be launched inside another
+# Claude Code session"). Failing to strip causes the ACP ``session/new``
+# call to close with ``Query closed before response received`` and the
+# TUI never reaches Ready, so the user sees "Agent is not ready" on
+# every keystroke.
+PARENT_CLAUDE_CODE_ENV_VARS: tuple[str, ...] = (
+    "CLAUDECODE",
+    "CLAUDE_CODE_ENTRYPOINT",
+    "CLAUDE_CODE_EXECPATH",
+    "CLAUDE_CODE_SESSION_ID",
+)
+
+
+def build_agent_subprocess_env(
+    parent_env: Mapping[str, str] | "os._Environ[str]",
+    cwd: str,
+) -> dict[str, str]:
+    """Build the env for the ``claude-code-acp`` subprocess.
+
+    Starts from the parent process env, sets ``TOAD_CWD`` so the adapter
+    knows the project root, eager-loads MCP tools by defaulting
+    ``ENABLE_TOOL_SEARCH=false`` (see
+    ``docs/canon-tui-fabrication-problem.md``), and strips the parent
+    Claude Code session vars listed in ``PARENT_CLAUDE_CODE_ENV_VARS``.
+
+    Args:
+        parent_env: The current process env (typically ``os.environ``).
+        cwd: Absolute path written into ``TOAD_CWD``.
+
+    Returns:
+        A new dict suitable for ``asyncio.create_subprocess_shell(env=...)``.
+        ``ENABLE_TOOL_SEARCH`` is preserved if already set in the parent,
+        so an operator can opt back into deferred-tool mode for debugging.
+    """
+    env = dict(parent_env)
+    env["TOAD_CWD"] = cwd
+    env.setdefault("ENABLE_TOOL_SEARCH", "false")
+    for var in PARENT_CLAUDE_CODE_ENV_VARS:
+        env.pop(var, None)
+    return env

--- a/tests/acp/test_agent_subprocess_env.py
+++ b/tests/acp/test_agent_subprocess_env.py
@@ -1,0 +1,64 @@
+"""Tests for ``build_agent_subprocess_env``.
+
+When canon is launched from a terminal that inherited ``CLAUDECODE=1``
+(a Claude Code session, or any child shell of one), the spawned
+``claude`` process detects the parent session and refuses to start.
+The ACP handshake then closes at ``session/new`` with ``Query closed
+before response received`` and the agent never reaches Ready.
+
+These tests pin the env-prep contract so the strip cannot regress
+silently — the symptom is invisible until a user actually types into
+the prompt.
+"""
+
+from __future__ import annotations
+
+from toad.acp.env_prep import (
+    PARENT_CLAUDE_CODE_ENV_VARS,
+    build_agent_subprocess_env,
+)
+
+
+def test_strips_all_known_claude_code_session_vars() -> None:
+    parent = {
+        "PATH": "/usr/bin",
+        "CLAUDECODE": "1",
+        "CLAUDE_CODE_ENTRYPOINT": "cli",
+        "CLAUDE_CODE_EXECPATH": "/Users/x/.local/share/claude/versions/2.1",
+        "CLAUDE_CODE_SESSION_ID": "deadbeef-1234",
+        "USER": "alice",
+    }
+
+    env = build_agent_subprocess_env(parent, "/some/project")
+
+    for var in PARENT_CLAUDE_CODE_ENV_VARS:
+        assert var not in env, f"{var} leaked into the child env"
+    # Unrelated vars are preserved.
+    assert env["PATH"] == "/usr/bin"
+    assert env["USER"] == "alice"
+
+
+def test_sets_toad_cwd_to_provided_path() -> None:
+    env = build_agent_subprocess_env({}, "/tmp/canon-demo")
+    assert env["TOAD_CWD"] == "/tmp/canon-demo"
+
+
+def test_defaults_enable_tool_search_to_false() -> None:
+    env = build_agent_subprocess_env({}, "/cwd")
+    assert env["ENABLE_TOOL_SEARCH"] == "false"
+
+
+def test_preserves_operator_override_of_enable_tool_search() -> None:
+    """An operator may set ENABLE_TOOL_SEARCH=true to debug deferred tools.
+
+    The helper only ``setdefault``s, so an explicit upstream value wins.
+    """
+    env = build_agent_subprocess_env({"ENABLE_TOOL_SEARCH": "true"}, "/cwd")
+    assert env["ENABLE_TOOL_SEARCH"] == "true"
+
+
+def test_returns_new_dict_not_alias_of_parent() -> None:
+    parent = {"PATH": "/usr/bin"}
+    env = build_agent_subprocess_env(parent, "/cwd")
+    env["TOAD_CWD"] = "/mutated"
+    assert "TOAD_CWD" not in parent


### PR DESCRIPTION
Hotfix against main. Supersedes #67 (which targeted `develop`) so the user-blocking bug ships to `main` without dragging the develop-only automation panel + jsonrpc + plan-tab work along.

## Symptom

Running `canon` from a terminal that inherited `CLAUDECODE=1` (a Claude Code session, or any child shell of one) loads the TUI fine, but every prompt submission flashes:

> Agent is not ready. Please wait while the agent connects…

…forever. No on-disk log explains why because canon-tui only reads the adapter's stderr on subprocess exit.

## Root cause

`claude-code-acp` spawns `claude`. Claude Code 2.x's nested-session guard reads `CLAUDECODE` and refuses:

```
Error: Claude Code cannot be launched inside another Claude Code session.
Nested sessions share runtime resources and will crash all active sessions.
To bypass this check, unset the CLAUDECODE environment variable.
```

The ACP `session/new` call then closes with `-32603 Query closed before response received`, the TUI's `agent_ready` stays `False`, and the user sees the not-ready flash on every keystroke.

Verified against `claude-code-acp@0.16.2` / `claude@2.1.153` (May 27). The same code worked on May 14 because the user's claude version then did not enforce the guard.

## Fix

New module `toad.acp.env_prep`:

- `build_agent_subprocess_env(parent_env, cwd)` — builds the subprocess env, sets `TOAD_CWD`, defaults `ENABLE_TOOL_SEARCH=false` (preserving the v0.7.21 behaviour), and pops `CLAUDECODE`, `CLAUDE_CODE_ENTRYPOINT`, `CLAUDE_CODE_EXECPATH`, `CLAUDE_CODE_SESSION_ID`.
- Lives in a standalone module to side-step the known `toad.acp.agent ↔ toad.acp.messages` circular import in tests.

`Agent._run_agent` calls the helper instead of building env inline.

## Tests

`tests/acp/test_agent_subprocess_env.py` pins the contract:

- strips all four `CLAUDE_CODE_*` vars
- preserves unrelated parent vars (PATH, USER, etc.)
- sets `TOAD_CWD`
- defaults `ENABLE_TOOL_SEARCH=false` but lets an operator override it (e.g. for debugging deferred-tool fabrication)
- returns a new dict, not an alias of the parent

`uv run pytest tests/acp/` → 19 passed.

## End-to-end repro

With v0.7.21 + `CLAUDECODE=1` set, against `claude-code-acp@0.16.2`:

```json
{"id":2,"error":{"code":-32603,"message":"Internal error",
 "data":{"details":"Query closed before response received"}}}
```

With this fix (`CLAUDECODE` stripped at the spawn boundary):

```json
{"id":2,"result":{"sessionId":"654c9f1b-…",
 "models":{"availableModels":[{"modelId":"default",…}]}}}
```

Confirmed live in the installed editable canon-tui — `canon` launched from a Claude Code session now connects and answers prompts.

## Version

0.7.21 → 0.7.22. Same pattern as v0.7.21 (#66), which also bundled a fix and a version bump in one PR. Tag manually after merge.

## Out of scope

`stderr` is still only read on subprocess exit, so a hung adapter still produces no on-disk evidence. That's a deeper restructure of `_run_agent` — separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)